### PR TITLE
fix: encrypt simplegroupchat content before broadcasting on-chain

### DIFF
--- a/SKILLs/metabot-omni-caster/scripts/omni-caster.js
+++ b/SKILLs/metabot-omni-caster/scripts/omni-caster.js
@@ -23,6 +23,22 @@ process.on('unhandledRejection', (reason, promise) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason);
     process.exit(1);
 });
+function groupIdToSecretKey(groupId) {
+    const normalized = String(groupId ?? '').trim();
+    if (normalized.length >= 16) {
+        return normalized.slice(0, 16);
+    }
+    return normalized.padEnd(16, '0');
+}
+function encryptSimpleGroupChatContent(message, groupId) {
+    const secretKey = groupIdToSecretKey(groupId);
+    const cipher = (0, crypto_1.createCipheriv)('aes-128-cbc', Buffer.from(secretKey, 'utf8'), Buffer.from('0000000000000000', 'utf8'));
+    const encrypted = Buffer.concat([
+        cipher.update(String(message ?? ''), 'utf8'),
+        cipher.final(),
+    ]);
+    return encrypted.toString('hex');
+}
 /** Infer MIME type from file extension. */
 function inferContentType(filePath) {
     const ext = path_1.default.extname(filePath).toLowerCase();
@@ -40,22 +56,6 @@ function inferContentType(filePath) {
         '.txt': 'text/plain',
     };
     return map[ext] ?? 'application/octet-stream';
-}
-function groupIdToSecretKey(groupId) {
-    const normalized = String(groupId ?? '').trim();
-    if (normalized.length >= 16) {
-        return normalized.slice(0, 16);
-    }
-    return normalized.padEnd(16, '0');
-}
-function encryptSimpleGroupChatContent(message, groupId) {
-    const secretKey = groupIdToSecretKey(groupId);
-    const cipher = (0, crypto_1.createCipheriv)('aes-128-cbc', Buffer.from(secretKey, 'utf8'), Buffer.from('0000000000000000', 'utf8'));
-    const encrypted = Buffer.concat([
-        cipher.update(String(message ?? ''), 'utf8'),
-        cipher.final(),
-    ]);
-    return encrypted.toString('hex');
 }
 async function main() {
     const { values, positionals } = (0, util_1.parseArgs)({

--- a/SKILLs/metabot-omni-caster/scripts/omni-caster.ts
+++ b/SKILLs/metabot-omni-caster/scripts/omni-caster.ts
@@ -14,6 +14,7 @@
 import { parseArgs } from 'util';
 import fs from 'fs';
 import path from 'path';
+import { createCipheriv } from 'crypto';
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);
@@ -28,6 +29,28 @@ interface ParsedArgs {
   'content-type'?: string;
   encoding?: string;
   help?: boolean;
+}
+
+function groupIdToSecretKey(groupId: string): string {
+  const normalized = String(groupId ?? '').trim();
+  if (normalized.length >= 16) {
+    return normalized.slice(0, 16);
+  }
+  return normalized.padEnd(16, '0');
+}
+
+function encryptSimpleGroupChatContent(message: string, groupId: string): string {
+  const secretKey = groupIdToSecretKey(groupId);
+  const cipher = createCipheriv(
+    'aes-128-cbc',
+    Buffer.from(secretKey, 'utf8'),
+    Buffer.from('0000000000000000', 'utf8')
+  );
+  const encrypted = Buffer.concat([
+    cipher.update(String(message ?? ''), 'utf8'),
+    cipher.final(),
+  ]);
+  return encrypted.toString('hex');
 }
 
 /** Infer MIME type from file extension. */
@@ -137,7 +160,20 @@ async function main(): Promise<void> {
     }
     if (contentType.toLowerCase().includes('json')) {
       try {
-        const parsed = JSON.parse(payloadStr);
+        const parsed = JSON.parse(payloadStr) as Record<string, unknown>;
+        if (args.path!.trim() === '/protocols/simplegroupchat') {
+          const groupId = typeof parsed.groupId === 'string' ? parsed.groupId.trim() : '';
+          if (!groupId) {
+            console.error('Payload for /protocols/simplegroupchat must include a non-empty groupId.');
+            process.exit(1);
+          }
+          if (typeof parsed.content !== 'string') {
+            console.error('Payload for /protocols/simplegroupchat must include a string content field.');
+            process.exit(1);
+          }
+          parsed.content = encryptSimpleGroupChatContent(parsed.content, groupId);
+          parsed.encryption = 'aes';
+        }
         cleanPayload = JSON.stringify(parsed);
       } catch {
         console.error('Payload is not valid JSON');

--- a/SKILLs/skills.config.json
+++ b/SKILLs/skills.config.json
@@ -25,7 +25,7 @@
     },
     "metabot-omni-caster": {
       "order": 10,
-      "version": "1.0.0",
+      "version": "1.0.1",
       "creator-metaid": "",
       "installedAt": 1740969600000,
       "enabled": true


### PR DESCRIPTION
## 问题描述

通过 `/protocols/simplegroupchat` 协议发送的群聊消息，`content` 字段以**明文**形式上链，尽管 payload 中已设置 `"encryption": "aes"`。

根本原因：`listSkills()` 中 userData 版本覆盖 bundled 版本，而 userData 中的旧 `omni-caster.js` 完全缺少 AES-128-CBC 加密逻辑，导致 `content` 在提交到 MetaID `create-pin` RPC 前从未被加密。

## 修改内容

### `omni-caster.ts` / `omni-caster.js`
- 新增 `groupIdToSecretKey(groupId)` — 将 groupId 转为 16 字节 AES 密钥（取前 16 位，不足则右补 `0`）
- 新增 `encryptSimpleGroupChatContent(message, groupId)` — 使用 Node.js 原生 `crypto` 模块进行 AES-128-CBC 加密（key = groupId 前 16 字符，IV = `0000000000000000` UTF-8 字节），输出 hex 字符串
- 在 JSON payload 解析块中，当 `--path` 为 `/protocols/simplegroupchat` 时，自动加密 `content` 字段并设置 `encryption: 'aes'`

### `skills.config.json`
- `metabot-omni-caster` 版本号 `1.0.0` → `1.0.1`，确保生产环境打包后 `syncBundledSkillsToUserData()` 能自动将修复后的 skill 同步到 userData 目录

## 测试验证

修复后，通过 omni-caster 发送的 `/protocols/simplegroupchat` 消息，上链 payload 中的 `content` 字段将为 AES-128-CBC 加密后的 hex 字符串，而非明文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)