### PR TITLE
fix: detach user_memories before DELETE FROM metabots to avoid FOREIGN KEY constraint failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ tests/*
 !tests/metabotInfoPayload.test.mjs
 !tests/metabotInfoSyncSteps.test.mjs
 !tests/metabotRestoreProtocol.test.mjs
+!tests/metabotDeleteWithMemories.test.mjs
 !tests/sqliteRecoveryLifecycle.test.mjs
 !tests/atomicFile.test.mjs
 !tests/sqliteBackgroundJobs.test.mjs

--- a/src/main/metabotStore.ts
+++ b/src/main/metabotStore.ts
@@ -640,7 +640,22 @@ export class MetabotStore {
     this.db.run('UPDATE metabots SET boss_id = NULL, updated_at = ? WHERE boss_id = ?', [Date.now(), id]);
     // Deliberately no cascade into cowork_sessions / user_memories: those rows
     // keep the deleted bot's metabot_id as the historical record of which bot
-    // produced them (experience data survives the bot itself).
+    // produced them (experience data survives the bot itself). But the native
+    // database opens with foreign_keys = ON, and user_memories.metabot_id /
+    // metaid_knowledge_entries.metabot_id reference metabots(id) with NO ACTION,
+    // so a bare DELETE fails with FOREIGN KEY constraint failed whenever the bot
+    // has any memory / knowledge rows (the UI then shows no reaction). Detach
+    // those rows first — user_memories keeps its content with metabot_id nulled,
+    // metaid_knowledge_entries is deleted (its metabot_id is NOT NULL) — so
+    // deletion always succeeds and leaves no orphaned references.
+    this.db.run('UPDATE user_memories SET metabot_id = NULL WHERE metabot_id = ?', [id]);
+    // metaid_knowledge_entries is SDK-managed and may not exist on every install;
+    // keep the cleanup best-effort so a missing table cannot break bot deletion.
+    try {
+      this.db.run('DELETE FROM metaid_knowledge_entries WHERE metabot_id = ?', [id]);
+    } catch (error) {
+      if (!(error instanceof Error) || !/no such table/i.test(error.message)) throw error;
+    }
     this.db.run('DELETE FROM metabots WHERE id = ?', [id]);
     this.saveDb();
     return true;

--- a/src/renderer/components/metabots/MetabotsManager.tsx
+++ b/src/renderer/components/metabots/MetabotsManager.tsx
@@ -663,18 +663,31 @@ const MetabotsManager: React.FC<MetabotsManagerProps> = ({
   const handleDeleteConfirm = async () => {
     if (!deleteTarget) return;
     const deletedId = deleteTarget.id;
-    const result = await window.electron.idbots.deleteMetaBot(deletedId);
-    if (result.success) {
-      setList((prev) => prev.filter((m) => m.id !== deletedId));
-      setDeleteTarget(null);
-      // If the deleted bot was open in the edit view, fall back to the list.
-      if (editId === deletedId) {
-        setEditId(null);
-        setViewMode('list');
+    try {
+      const result = await window.electron.idbots.deleteMetaBot(deletedId);
+      if (result.success) {
+        setList((prev) => prev.filter((m) => m.id !== deletedId));
+        setDeleteTarget(null);
+        // If the deleted bot was open in the edit view, fall back to the list.
+        if (editId === deletedId) {
+          setEditId(null);
+          setViewMode('list');
+        }
+        window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('metabotDeleteSuccess') }));
+      } else {
+        // Close the modal and surface the real error via toast. Previously the
+        // failure was only written to actionError behind the modal overlay, which
+        // made a failed delete look like it "did nothing".
+        setDeleteTarget(null);
+        window.dispatchEvent(new CustomEvent('app:showToast', { detail: result.error || i18nService.t('metabotUpdateFailed') }));
       }
-      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('metabotDeleteSuccess') }));
-    } else {
-      setActionError(result.error || i18nService.t('metabotUpdateFailed'));
+    } catch (error) {
+      setDeleteTarget(null);
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', {
+          detail: error instanceof Error ? error.message : i18nService.t('metabotUpdateFailed'),
+        })
+      );
     }
   };
   const performSyncToChain = async (metabot: Metabot) => {

--- a/tests/metabotDeleteWithMemories.test.mjs
+++ b/tests/metabotDeleteWithMemories.test.mjs
@@ -1,0 +1,199 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const { SqliteStore } = require('../dist-electron/main/sqliteStore.js');
+const { MetabotStore } = require('../dist-electron/main/metabotStore.js');
+
+const makeTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'idbots-delete-metabot-fk-'));
+
+const insertWallet = (db, id) => {
+  db.run(
+    `INSERT INTO metabot_wallets (id, mnemonic, path, created_at)
+     VALUES (?, ?, ?, ?)`,
+    [id, `abandon ability able about above absent absorb abstract absurd abuse access accident ${id}`, "m/44'/10001'/0'/0/0", 1700000000000 + id]
+  );
+};
+
+const insertMetabot = (db, { id, walletId, name, type = 'worker', createdAt }) => {
+  db.run(
+    `INSERT INTO metabots (
+      id, wallet_id, mvc_address, btc_address, doge_address, public_key, chat_public_key,
+      name, enabled, metaid, metabot_type, created_by, role, soul,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      walletId,
+      `mvc-${id}`,
+      `btc-${id}`,
+      `doge-${id}`,
+      `public-${id}`,
+      `chat-public-${id}`,
+      name,
+      1,
+      `metaid-${id}`,
+      type,
+      '0000',
+      `${name} role`,
+      `${name} soul`,
+      createdAt,
+      createdAt,
+    ]
+  );
+};
+
+const insertMemory = (db, { id, metabotId, text }) => {
+  db.run(
+    `INSERT INTO user_memories (id, metabot_id, text, fingerprint, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, metabotId, text, `fp-${id}`, 1700000000000 + id, 1700000000000 + id]
+  );
+};
+
+// metaid_knowledge_entries is SDK-managed and not created by SqliteStore, so a
+// test that exercises the deleteMetabot cleanup must create the table itself,
+// mirroring the runtime schema (NOT NULL metabot_id, FK NO ACTION on metabots).
+const ensureKnowledgeTable = (db) => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS metaid_knowledge_entries (
+      id TEXT PRIMARY KEY,
+      metabot_id INTEGER NOT NULL REFERENCES metabots(id),
+      topic TEXT NOT NULL,
+      topic_fingerprint TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      category TEXT,
+      tags_json TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('active', 'superseded', 'archived')),
+      origin TEXT NOT NULL,
+      source_dream_date TEXT,
+      version INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      last_used_at INTEGER
+    );
+  `);
+};
+
+const insertKnowledge = (db, { id, metabotId, topic }) => {
+  db.run(
+    `INSERT INTO metaid_knowledge_entries
+      (id, metabot_id, topic, topic_fingerprint, summary, kind, tags_json, confidence, status, origin, version, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, metabotId, topic, `fp-${id}`, `summary-${id}`, 'know_how', '[]', 0.5, 'active', 'agent', 1, 1700000000000 + id, 1700000000000 + id]
+  );
+};
+
+const openStores = async (tempDir) => {
+  const store = await SqliteStore.create(tempDir);
+  const metabotStore = new MetabotStore(store.getDatabase(), store.getSaveFunction());
+  return { store, metabotStore, db: store.getDatabase() };
+};
+
+const foreignKeysEnabled = (db) => {
+  const result = db.exec('PRAGMA foreign_keys;');
+  return Number(result[0]?.values?.[0]?.[0]);
+};
+
+const countMemoriesForBot = (db, metabotId) => {
+  const result = db.exec('SELECT COUNT(*) FROM user_memories WHERE metabot_id = ?', [metabotId]);
+  return Number(result[0].values[0][0]);
+};
+
+const countNulledMemories = (db) => {
+  const result = db.exec('SELECT COUNT(*) FROM user_memories WHERE metabot_id IS NULL');
+  return Number(result[0].values[0][0]);
+};
+
+test('deleteMetabot on a bot with attached user_memories succeeds and preserves the rows (metabot_id nulled)', async () => {
+  const tempDir = makeTempDir();
+  const { store, metabotStore, db } = await openStores(tempDir);
+  try {
+    // The regression env must enforce foreign keys, or this test proves nothing.
+    assert.equal(foreignKeysEnabled(db), 1);
+
+    insertWallet(db, 1);
+    insertMetabot(db, { id: 7, walletId: 1, name: 'Memoried Bot', createdAt: 1000 });
+    insertMemory(db, { id: 'mem-1', metabotId: 7, text: 'prefers morning standups' });
+    insertMemory(db, { id: 'mem-2', metabotId: 7, text: 'dislikes noisy rooms' });
+
+    assert.equal(countMemoriesForBot(db, 7), 2);
+
+    const deleted = metabotStore.deleteMetabot(7);
+
+    assert.equal(deleted, true);
+    assert.equal(metabotStore.getMetabotById(7), null);
+    // Memory rows survive the bot as history, detached from the deleted bot.
+    assert.equal(countMemoriesForBot(db, 7), 0);
+    assert.equal(countNulledMemories(db), 2);
+    const rows = db.exec('SELECT id, text FROM user_memories WHERE id IN (?, ?)', ['mem-1', 'mem-2'])[0].values;
+    assert.deepEqual(new Set(rows.map((r) => r[1])), new Set(['prefers morning standups', 'dislikes noisy rooms']));
+  } finally {
+    store.close();
+  }
+});
+
+test('raw DELETE of a referenced bot is rejected while memories still reference it (FK NO ACTION enforced)', async () => {
+  const tempDir = makeTempDir();
+  const { store, metabotStore, db } = await openStores(tempDir);
+  try {
+    assert.equal(foreignKeysEnabled(db), 1);
+
+    insertWallet(db, 1);
+    insertMetabot(db, { id: 7, walletId: 1, name: 'Referenced Bot', createdAt: 1000 });
+    insertMemory(db, { id: 'mem-1', metabotId: 7, text: 'keeps me pinned' });
+
+    // Without the app-layer detach, the delete is refused by the constraint.
+    assert.throws(() => db.run('DELETE FROM metabots WHERE id = ?', [7]), /FOREIGN KEY constraint failed/);
+    assert.equal(metabotStore.getMetabotById(7) !== null, true);
+
+    // After the fix path detaches the memory, the delete goes through.
+    assert.equal(metabotStore.deleteMetabot(7), true);
+    assert.equal(countNulledMemories(db), 1);
+  } finally {
+    store.close();
+  }
+});
+
+test('deleteMetabot also removes the bot metaid_knowledge_entries rows (NOT NULL metabot_id)', async () => {
+  const tempDir = makeTempDir();
+  const { store, metabotStore, db } = await openStores(tempDir);
+  try {
+    assert.equal(foreignKeysEnabled(db), 1);
+
+    ensureKnowledgeTable(db);
+    insertWallet(db, 1);
+    insertMetabot(db, { id: 7, walletId: 1, name: 'Knowledgeable Bot', createdAt: 1000 });
+    insertKnowledge(db, { id: 'k-1', metabotId: 7, topic: 'sqlite fk pitfall' });
+
+    const before = db.exec('SELECT COUNT(*) FROM metaid_knowledge_entries WHERE metabot_id = 7');
+    assert.equal(Number(before[0].values[0][0]), 1);
+
+    assert.equal(metabotStore.deleteMetabot(7), true);
+    assert.equal(metabotStore.getMetabotById(7), null);
+    const after = db.exec('SELECT COUNT(*) FROM metaid_knowledge_entries WHERE metabot_id = 7');
+    assert.equal(Number(after[0].values[0][0]), 0);
+    // The knowledge table survives with no orphaned references.
+    const orphans = db.exec("SELECT COUNT(*) FROM pragma_foreign_key_check WHERE parent = 'metabots'");
+    assert.equal(Number(orphans[0].values[0][0]), 0);
+  } finally {
+    store.close();
+  }
+});
+
+test('deleteMetabot on an unknown id is a no-op returning false', async () => {
+  const tempDir = makeTempDir();
+  const { store, metabotStore } = await openStores(tempDir);
+  try {
+    assert.equal(metabotStore.deleteMetabot(424242), false);
+  } finally {
+    store.close();
+  }
+});


### PR DESCRIPTION
## Problem

Deleting any bot that has stored memories fails with `FOREIGN KEY constraint failed (19)`.

Root cause chain:
1. `user_memories.metabot_id INTEGER REFERENCES metabots(id)` has **no `ON DELETE` clause** (SQLite default is NO ACTION — the parent row cannot be deleted while child rows reference it). Defined at `src/main/sqliteStore.ts:351` (CREATE TABLE) and `src/main/sqliteStore.ts:1456` / `src/main/coworkStore.ts:1153` (ALTER TABLE migrations).
2. Every database connection forces `PRAGMA foreign_keys = ON` (`src/main/nativeSqliteDatabase.ts:58`), so the constraint is actually enforced.
3. `deleteMetabot` (`src/main/metabotStore.ts`) only ran `UPDATE metabots SET boss_id = NULL` and `DELETE FROM metabots WHERE id = ?`, never releasing `user_memories.metabot_id`. Its comment says it deliberately does not cascade `user_memories` to preserve history — which directly conflicts with the NO ACTION FK, so the delete is rejected by the database.

Reproduction: with `PRAGMA foreign_keys=ON`, `DELETE FROM metabots WHERE id = <bot-with-memories>` fails; clearing the memory references first makes the delete succeed. `cowork_sessions` and `metabot_memory_policies` are `ON DELETE CASCADE` and are not blockers.

## Fix

In `deleteMetabot`, **before** `DELETE FROM metabots`, run:

```sql
UPDATE user_memories SET metabot_id = NULL WHERE metabot_id = ?
```

This detaches memory rows from the deleted bot instead of cascading them — preserving the original intent (experience data survives the bot itself) while satisfying the enforced FK. `boss_id` cleanup is unchanged.

Chosen as an application-layer fix to avoid a high-cost table rebuild migration; a schema-level `ON DELETE SET NULL` could be evaluated separately.

## Verification

- **New regression tests** (`tests/metabotDeleteWithMemories.test.mjs`, `node --test` .mjs pattern):
  - `deleteMetabot` on a bot with 2 attached memories succeeds under `foreign_keys=ON`; memory rows survive with `metabot_id` set to `NULL`; bot row is gone.
  - Raw `DELETE FROM metabots` with an attached memory is rejected (`FOREIGN KEY constraint failed`) — proving the constraint is enforced and the fix is required.
  - Deleting an unknown id is a no-op returning `false`.
  - All pass: `node --test tests/metabotDeleteWithMemories.test.mjs` → 3 pass / 0 fail.
- **TypeScript compile**: `npx -p typescript@5.9.3 tsc --project electron-tsconfig.json` — error set identical before/after this change (zero new errors; remaining errors are pre-existing, in unrelated files).
- **No real data touched**: verification used temporary databases under `os.tmpdir()` only.
- Related existing suites (metabotTwinType, metabotSettings, memoryScopedCrud, memoryScopedRecall, metabotAttribution, metabotFallbackLlm, metabotWalletService): 27 pass; 2 pre-existing failures in `metabotAccountService.test.mjs` (wrong require path `dist-electron/services/...` instead of `dist-electron/main/services/...`; reproduced without this change).

---

## Update (2026-08-13)

The fix is consolidated and extended on top of the latest `main` (0.4.6):

- **`metaid_knowledge_entries` cleanup**: this SDK-managed table also references `metabots(id)` with NO ACTION, and its `metabot_id` column is `NOT NULL` — so a bot with knowledge rows hit the same failure. `deleteMetabot` now deletes the bot's knowledge rows (best-effort, guarded for installs where the SDK table is absent).
- **Frontend error surfacing**: a failed delete previously left the confirm modal open with the error written to `actionError` behind the overlay, so it looked like the delete did nothing. `handleDeleteConfirm` now closes the modal and shows the real error via toast (both for failed IPC results and thrown errors), preserving the existing edit-view fallback.
- **Tests**: the regression suite now also covers the `metaid_knowledge_entries` cleanup under `foreign_keys=ON` (4 tests, all pass).