### PR TITLE
fix(bot-browser): support preview-metaapp URIs in browser-open RPC and skill

### DIFF
--- a/SKILLs/metabot-browser-open/SKILL.md
+++ b/SKILLs/metabot-browser-open/SKILL.md
@@ -13,6 +13,7 @@ Open or control the existing IDBots top Bot Browser. Do not use this skill for s
 Use `scripts/index.js` for deterministic target parsing and Browser opening. The script normalizes:
 
 - `metaapp://<pinId>` as a MetaApp URI.
+- `preview-metaapp://localhost/<absolute-path>` as a local preview URI (the host resolves the local path; equivalent to `bot_browser_preview_local`).
 - `pin://<pinId>` as a chain pin URI.
 - `metafile://<pinId-or-path>` as a MetaFile URI.
 - `map://...` as a MAP protocol URI.

--- a/SKILLs/metabot-browser-open/scripts/index.js
+++ b/SKILLs/metabot-browser-open/scripts/index.js
@@ -10,7 +10,7 @@ const TABS_PATH = '/api/idbots/bot-browser/tabs';
 const TAB_ACTIONS = new Set(['open-tab', 'close-tab', 'switch-tab', 'get-tabs', 'get-active-tab']);
 const PIN_ID_RE = /\b[0-9a-f]{64}i0\b/i;
 const GLOBAL_META_ID_RE = /\bid[qprzyt]1[a-z0-9]{20,}\b/i;
-const SUPPORTED_URI_RE = /\b(metaid|pin|metaapp|map|metafile):\/\/[^\s"'<>，。！？、]+/i;
+const SUPPORTED_URI_RE = /\b(preview-metaapp|metaid|pin|metaapp|map|metafile):\/\/[^\s"'<>，。！？、]+/i;
 const ANY_URI_SCHEME_RE = /\b([a-z][a-z0-9+.-]*):\/\//i;
 const WEB3_DOMAIN_RE = /\b[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\.(?:eth|lens|crypto|nft|wallet|bitcoin|btc|dao|888|zil|blockchain|polygon|sol|arb|base)\b/i;
 const TRAILING_PUNCTUATION_RE = /[),.;!?，。！？、）]+$/;
@@ -27,7 +27,7 @@ function normalizeSupportedUri(rawUri) {
   }
 
   const scheme = match[1].toLowerCase();
-  if (!['metaid', 'pin', 'metaapp', 'map', 'metafile'].includes(scheme)) {
+  if (!['preview-metaapp', 'metaid', 'pin', 'metaapp', 'map', 'metafile'].includes(scheme)) {
     return null;
   }
 
@@ -36,7 +36,10 @@ function normalizeSupportedUri(rawUri) {
     return null;
   }
 
-  return `${scheme}://${scheme === 'map' ? rest : rest.toLowerCase()}`;
+  // Local file paths under preview-metaapp:// are case-sensitive; keep the
+  // authority/path verbatim (like map://), unlike on-chain URI hosts.
+  const keepsCase = scheme === 'preview-metaapp' || scheme === 'map';
+  return `${scheme}://${keepsCase ? rest : rest.toLowerCase()}`;
 }
 
 function pickPayloadTarget(payload) {

--- a/src/main/services/metaidRpcServer.ts
+++ b/src/main/services/metaidRpcServer.ts
@@ -87,7 +87,7 @@ const GROUP_TASK_DELIVERABLE_DELETE_PATH = '/api/idbots/group-task/deliverable-d
 const GROUP_TASK_SEARCH_REMOTE_PATH = '/api/idbots/group-task/search-remote-candidates';
 const GROUP_TASK_INVITE_REMOTE_PATH = '/api/idbots/group-task/invite-remote';
 const LIST_METABOTS_PATH = '/api/idbots/list-metabots';
-const BOT_BROWSER_URI_SCHEMES = new Set(['metaid', 'pin', 'metaapp', 'map', 'metafile']);
+const BOT_BROWSER_URI_SCHEMES = new Set(['metaid', 'pin', 'metaapp', 'map', 'metafile', 'preview-metaapp']);
 
 export type BotBrowserRpcOpenRequest = {
   uri: string;
@@ -148,11 +148,23 @@ function normalizeBotBrowserUri(value: unknown): string {
     throw new Error(`unsupported Bot Browser URI scheme: ${scheme}`);
   }
 
-  if (!match[2].trim() || /\s/.test(match[2])) {
+  const authority = match[2].trim();
+  if (scheme === 'preview-metaapp') {
+    // preview-metaapp is a local preview channel only: the renderer resolves a
+    // local path when the host is exactly 'localhost' (it never equals
+    // 'localhost:<port>'). Reject other hosts so this RPC cannot be used to
+    // point the Bot Browser at arbitrary https URLs.
+    const host = authority.split('/')[0];
+    if (host !== 'localhost') {
+      throw new Error('preview-metaapp URIs must use localhost as the host');
+    }
+  }
+
+  if (!authority || /\s/.test(authority)) {
     throw new Error('uri must not contain whitespace');
   }
 
-  return `${scheme}://${match[2].trim()}`;
+  return `${scheme}://${authority}`;
 }
 
 function normalizeOptionalActorId(value: unknown): string | null {


### PR DESCRIPTION
## Problem

`metabot-browser-open` and the local RPC `POST /api/idbots/bot-browser/open` rejected `preview-metaapp://` URIs, so a local preview could not be opened through the skill path even though the Bot Browser renderer already supports the scheme (it is the same URI family used by `bot_browser_preview_local`).

Two concrete failures:

1. The skill script's `SUPPORTED_URI_RE` regex (`\b(metaid|pin|metaapp|map|metafile)://`) matched `metaapp://` *inside* `preview-metaapp://`, silently stripping the `preview-` prefix and navigating the Bot Browser to an invalid `metaapp://localhost/...` address.
2. The RPC server whitelist `BOT_BROWSER_URI_SCHEMES` did not include `preview-metaapp`, returning `unsupported Bot Browser URI scheme: preview-metaapp` even when the exact URI was posted.

## Changes

- **`SKILLs/metabot-browser-open/scripts/index.js`**
  - Recognize `preview-metaapp` first in `SUPPORTED_URI_RE` so it is no longer split into `metaapp://`.
  - Allow `preview-metaapp` in `normalizeSupportedUri` and keep its authority/path case-sensitive (local file paths), matching how `map://` is already treated.

- **`src/main/services/metaidRpcServer.ts`**
  - Add `preview-metaapp` to `BOT_BROWSER_URI_SCHEMES`.
  - Restrict `preview-metaapp` to the `localhost` host in `normalizeBotBrowserUri`, matching the renderer's `preview-metaapp` resolver (which resolves local previews only when host is exactly `localhost`). This keeps the RPC from being used to point the Bot Browser at arbitrary `https://` URLs.

- **`SKILLs/metabot-browser-open/SKILL.md`**
  - Document the `preview-metaapp://localhost/<absolute-path>` route target.

## Verification

- Skill script dry-run normalization passes for `preview-metaapp://localhost/<abs-path>` (case preserved), mixed-case `Preview-MetaApp://` scheme, and existing behaviors (`metaapp://` pin, bare pin, bare globalMetaID).
- `normalizeBotBrowserUri` edge cases: accepts `preview-metaapp://localhost/...`, rejects non-localhost hosts and `localhost:<port>`.
- `npm run compile:electron` passes with 0 errors.
- `eslint` on `metaidRpcServer.ts` passes with 0 warnings.

## Notes / risk

This widens the RPC open-URI input by one scheme. Risk is bounded because `preview-metaapp` is only accepted with a `localhost` host, and the renderer only serves local disk previews for that host. The change does not alter any other whitelisted scheme.