### PR TITLE
fix(gig-square): reject service publish/modify when provider skill not installed

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -408,6 +408,7 @@ import {
   buildGigSquareServicePayload,
   normalizeGigSquareModifyDraft,
   validateGigSquareModifyDraft,
+  validateGigSquareProviderSkillAvailability,
   validateGigSquareServiceMutation,
   type GigSquareModifyDraft,
 } from './services/gigSquareServiceMutationService';
@@ -11309,6 +11310,14 @@ if (!gotTheLock) {
       }
       const normalizedDraft = normalizeGigSquareModifyDraft(draft);
 
+      const skillAvailabilityValidation = validateGigSquareProviderSkillAvailability({
+        providerSkills: normalizedDraft.providerSkills,
+        installedSkills: getSkillManager().listSkills(),
+      });
+      if (!skillAvailabilityValidation.ok) {
+        return { success: false, error: skillAvailabilityValidation.error, errorCode: skillAvailabilityValidation.errorCode };
+      }
+
       let settlement;
       try {
         settlement = normalizeGigSquareSettlementDraft({
@@ -11566,6 +11575,14 @@ if (!gotTheLock) {
         return { success: false, error: draftValidation.error, errorCode: draftValidation.errorCode };
       }
       const normalizedDraft = normalizeGigSquareModifyDraft(draft);
+
+      const skillAvailabilityValidation = validateGigSquareProviderSkillAvailability({
+        providerSkills: normalizedDraft.providerSkills,
+        installedSkills: getSkillManager().listSkills(),
+      });
+      if (!skillAvailabilityValidation.ok) {
+        return { success: false, error: skillAvailabilityValidation.error, errorCode: skillAvailabilityValidation.errorCode };
+      }
 
       const store = getMetabotStore();
       const creatorMetabot = store.getMetabotById(validation.creatorMetabotId);

--- a/src/main/services/gigSquareServiceMutationService.ts
+++ b/src/main/services/gigSquareServiceMutationService.ts
@@ -403,6 +403,71 @@ export const validateGigSquareModifyDraft = (draft: GigSquareModifyDraft): GigSq
   return { ok: true };
 };
 
+export interface GigSquareInstalledSkillSnapshot {
+  id: string;
+  name: string;
+}
+
+/**
+ * Cross-checks the self-declared providerSkills against the host's installed
+ * skills (snapshot of skillManager.listSkills()). A declared skill counts as
+ * available when it resolves to an installed skill by id or name, mirroring the
+ * order-side resolution semantics (case-insensitive name match, and id match
+ * tolerant of underscore/hyphen variants via resolveSkillById candidates).
+ *
+ * Missing skills reject the publish/modify draft with an error that lists the
+ * missing skill names (e.g. "seedance").
+ *
+ * NOTE: availability here is installation-level (skill directory present on the
+ * host). It does not probe runtime executability (e.g. ARK_API_KEY for
+ * seedance), which skillManager.listSkills() cannot verify.
+ */
+export const validateGigSquareProviderSkillAvailability = (input: {
+  providerSkills: string[];
+  installedSkills: GigSquareInstalledSkillSnapshot[];
+}): GigSquareMutationValidationResult => {
+  const declaredSkills = normalizeProviderSkillList(input.providerSkills);
+  if (declaredSkills.length === 0) {
+    // Empty allow-list is not this validator's concern; draft validation
+    // already enforces provider_skill_required. Keep it a pass-through so the
+    // two validators stay composable.
+    return { ok: true };
+  }
+
+  const installedKeys = new Set<string>();
+  for (const skill of input.installedSkills || []) {
+    const skillId = toSafeString(skill.id).trim();
+    const skillName = toSafeString(skill.name).trim();
+    if (skillId) {
+      const lowered = skillId.toLowerCase();
+      installedKeys.add(lowered);
+      installedKeys.add(lowered.replace(/_/g, '-'));
+      installedKeys.add(lowered.replace(/-/g, '_'));
+    }
+    if (skillName) {
+      installedKeys.add(skillName.trim().toLowerCase());
+    }
+  }
+
+  const missingSkills = declaredSkills.filter((declared) => {
+    const lowered = declared.toLowerCase();
+    if (installedKeys.has(lowered)) return false;
+    if (installedKeys.has(lowered.replace(/_/g, '-'))) return false;
+    if (installedKeys.has(lowered.replace(/-/g, '_'))) return false;
+    return true;
+  });
+
+  if (missingSkills.length === 0) return { ok: true };
+
+  return {
+    ok: false,
+    error: missingSkills.length === 1
+      ? `Skill not installed on this host: ${missingSkills[0]}`
+      : `Skills not installed on this host: ${missingSkills.join(', ')}`,
+    errorCode: 'provider_skill_not_installed',
+  };
+};
+
 export const buildGigSquareServicePayload = (input: {
   draft: GigSquareModifyDraft;
   providerGlobalMetaId: string;

--- a/tests/gigSquareServiceMutationService.test.mjs
+++ b/tests/gigSquareServiceMutationService.test.mjs
@@ -10,14 +10,15 @@ const {
   validateGigSquareServiceMutation,
   normalizeGigSquareModifyDraft,
   validateGigSquareModifyDraft,
+  validateGigSquareProviderSkillAvailability,
   buildGigSquareServicePayload,
   resolveGigSquareSettlementPaymentAddress,
   buildGigSquareRevokeMetaidPayload,
   buildGigSquareModifyMetaidPayload,
-} = require('../dist-electron/services/gigSquareServiceMutationService.js');
+} = require('../dist-electron/main/services/gigSquareServiceMutationService.js');
 const {
   normalizeGigSquareSettlementDraft,
-} = require('../dist-electron/shared/gigSquareSettlementAsset.js');
+} = require('../dist-electron/main/shared/gigSquareSettlementAsset.js');
 
 test('validateGigSquareServiceMutation rejects missing target service', () => {
   const result = validateGigSquareServiceMutation({
@@ -594,4 +595,97 @@ test('buildGigSquareLocalServiceRecordForModify creates a local overlay row when
   assert.equal(record.displayName, 'Weather Pro');
   assert.equal(record.outputType, 'image');
   assert.equal(record.revokedAt, null);
+});
+
+test('validateGigSquareProviderSkillAvailability rejects declared skills absent from the host and lists them', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: ['seedance', 'video-pro'],
+    installedSkills: [],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'provider_skill_not_installed');
+  assert.match(result.error || '', /seedance/);
+  assert.match(result.error || '', /video-pro/);
+});
+
+test('validateGigSquareProviderSkillAvailability rejects when only some declared skills are missing', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: ['seedance', 'ghost-skill'],
+    installedSkills: [
+      { id: 'seedance', name: 'Seedance 视频生成' },
+      { id: 'local-tools', name: 'local-tools' },
+    ],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'provider_skill_not_installed');
+  assert.match(result.error || '', /ghost-skill/);
+  assert.doesNotMatch(result.error || '', /seedance/);
+});
+
+test('validateGigSquareProviderSkillAvailability accepts declared skills installed on the host by id', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: ['seedance'],
+    installedSkills: [{ id: 'seedance', name: 'Seedance 视频生成' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareProviderSkillAvailability accepts declared skills installed by name (case-insensitive)', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: ['Seedance'],
+    installedSkills: [{ id: 'seedance', name: 'seedance' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareProviderSkillAvailability accepts underscore/hyphen id variants like the order side', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: ['report_writer'],
+    installedSkills: [{ id: 'report-writer', name: 'report-writer' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareProviderSkillAvailability passes through an empty declared list without false rejection', () => {
+  const result = validateGigSquareProviderSkillAvailability({
+    providerSkills: [],
+    installedSkills: [],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('publish-side draft flow: installed skills pass, missing skills are rejected with the skill name listed', () => {
+  const installed = [{ id: 'seedance', name: 'seedance' }];
+  const draft = {
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  };
+
+  const draftValidation = validateGigSquareModifyDraft(draft);
+  assert.equal(draftValidation.ok, true);
+  const normalized = normalizeGigSquareModifyDraft(draft);
+  const available = validateGigSquareProviderSkillAvailability({
+    providerSkills: normalized.providerSkills,
+    installedSkills: installed,
+  });
+  assert.equal(available.ok, true);
+
+  const missing = validateGigSquareProviderSkillAvailability({
+    providerSkills: normalized.providerSkills,
+    installedSkills: [],
+  });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.errorCode, 'provider_skill_not_installed');
+  assert.match(missing.error || '', /seedance/);
 });


### PR DESCRIPTION
## 背景
Issue #10：服务市场不校验服务真实可用性。发布侧仅规范化自声明的 providerSkills（normalizeProviderSkillList），validateGigSquareModifyDraft 只查非空与格式，全程无 listSkills() 交叉校验——发布=自声明，无「可执行」维度，宿主缺运行时依赖（如 ARK_API_KEY）时服务仍可被搜索/邀请/下单，执行失败后超时退款。

## 修复
- 新增 validateGigSquareProviderSkillAvailability（gigSquareServiceMutationService.ts）：自声明技能与 skillManager.listSkills() 快照交叉校验，按 id / 大小写不敏感名称匹配，容忍下划线-连字符变体；缺失技能拒绝发布且错误信息列出缺失技能名，errorCode provider_skill_not_installed；空列表 pass-through（由既有 provider_skill_required 负责）
- main.ts 服务发布（create）与服务修改（modify）双路径接入
- 边界如实声明：本校验为安装级可用性（技能目录存在），不探测运行时可执行性（如 ARK_API_KEY）

## 测试
- 新增 validator 单测 7 组，全量 31/31 通过（node --test）
- 未执行：live 冒烟、链上验证、真实宿主下单验证——合并后由验收方独立补验

关联 #10