### PR TITLE
fix(gig-square): 发布/修改时校验服务声明技能真实可用性，缺失技能拒绝并列出名称 (#10)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11303,7 +11303,9 @@ if (!gotTheLock) {
         mrc20Id,
         outputType,
       };
-      const draftValidation = validateGigSquareModifyDraft(draft);
+      const draftValidation = validateGigSquareModifyDraft(draft, {
+        installedSkills: getSkillManager().listSkills(),
+      });
       if (!draftValidation.ok) {
         return { success: false, error: draftValidation.error, errorCode: draftValidation.errorCode };
       }
@@ -11561,7 +11563,9 @@ if (!gotTheLock) {
         metadata: hasMetadataParam ? toSafeString(params?.metadata) : toSafeString(currentService.metadata),
         outputType: toSafeString(params?.outputType).trim() || 'text',
       };
-      const draftValidation = validateGigSquareModifyDraft(draft);
+      const draftValidation = validateGigSquareModifyDraft(draft, {
+        installedSkills: getSkillManager().listSkills(),
+      });
       if (!draftValidation.ok) {
         return { success: false, error: draftValidation.error, errorCode: draftValidation.errorCode };
       }

--- a/src/main/services/gigSquareServiceMutationService.ts
+++ b/src/main/services/gigSquareServiceMutationService.ts
@@ -343,7 +343,59 @@ export const normalizeGigSquareModifyDraft = (draft: GigSquareModifyDraft): GigS
   };
 };
 
-export const validateGigSquareModifyDraft = (draft: GigSquareModifyDraft): GigSquareMutationValidationResult => {
+/**
+ * Minimal shape of an installed host skill as reported by
+ * `SkillManager.listSkills()`. Only `id` (skill directory basename) and
+ * `name` (SKILL.md frontmatter name, falling back to the directory basename)
+ * are needed for the publish-time availability cross-check.
+ */
+export interface GigSquareInstalledSkillDescriptor {
+  id: string;
+  name: string;
+}
+
+/**
+ * Pure cross-check that mirrors the runtime skill resolution semantics used
+ * when an order is executed (`SkillManager.resolveSkillById` /
+ * `resolveSkillByName`): a claimed provider skill is considered available on
+ * this host when it matches an installed skill by id (with `_`/`-` variant
+ * normalization) or by case-insensitive name.
+ *
+ * Returns the claimed skills that are NOT installed on this host, in the
+ * order they were declared. The caller decides whether to reject the
+ * publish/modify draft; this helper only computes the gap.
+ */
+export const resolveMissingProviderSkills = (
+  providerSkills: string[],
+  installedSkills: GigSquareInstalledSkillDescriptor[],
+): string[] => {
+  const claims = normalizeProviderSkillList(providerSkills);
+  if (claims.length === 0 || installedSkills.length === 0) return claims;
+
+  const exactMatches = new Set<string>();
+  const idCandidates = new Set<string>();
+  const nameIndex = new Set<string>();
+  for (const skill of installedSkills) {
+    exactMatches.add(skill.id);
+    exactMatches.add(skill.name.trim());
+    for (const candidate of [skill.id, skill.id.replace(/_/g, '-'), skill.id.replace(/-/g, '_')]) {
+      if (candidate) idCandidates.add(candidate);
+    }
+    const normalizedName = skill.name.trim().toLowerCase();
+    if (normalizedName) nameIndex.add(normalizedName);
+  }
+
+  return claims.filter((claim) => {
+    if (exactMatches.has(claim)) return false;
+    if (idCandidates.has(claim)) return false;
+    return !nameIndex.has(claim.toLowerCase());
+  });
+};
+
+export const validateGigSquareModifyDraft = (
+  draft: GigSquareModifyDraft,
+  options?: { installedSkills?: GigSquareInstalledSkillDescriptor[] },
+): GigSquareMutationValidationResult => {
   const normalized = normalizeGigSquareModifyDraft(draft);
   const rawPaymentTiming = toSafeString(draft.paymentTiming).trim().toLowerCase();
   const rawPrice = toSafeString(draft.price).trim();
@@ -396,6 +448,22 @@ export const validateGigSquareModifyDraft = (draft: GigSquareModifyDraft): GigSq
         ok: false,
         error: error instanceof Error ? error.message : 'currency is invalid',
         errorCode: 'currency_invalid',
+      };
+    }
+  }
+
+  // Host-side availability cross-check: a publish/modify must not declare
+  // provider skills this host cannot actually execute. Runs last so existing
+  // validation precedence is preserved, and only when the caller provides the
+  // installed-skill list (legacy callers without the option keep prior
+  // behavior).
+  if (options?.installedSkills) {
+    const missingSkills = resolveMissingProviderSkills(normalized.providerSkills, options.installedSkills);
+    if (missingSkills.length > 0) {
+      return {
+        ok: false,
+        error: `providerSkill is not available on this host: ${missingSkills.join(', ')}`,
+        errorCode: 'provider_skill_not_available',
       };
     }
   }

--- a/tests/gigSquareServiceMutationService.test.mjs
+++ b/tests/gigSquareServiceMutationService.test.mjs
@@ -14,10 +14,11 @@ const {
   resolveGigSquareSettlementPaymentAddress,
   buildGigSquareRevokeMetaidPayload,
   buildGigSquareModifyMetaidPayload,
-} = require('../dist-electron/services/gigSquareServiceMutationService.js');
+  resolveMissingProviderSkills,
+} = require('../dist-electron/main/services/gigSquareServiceMutationService.js');
 const {
   normalizeGigSquareSettlementDraft,
-} = require('../dist-electron/shared/gigSquareSettlementAsset.js');
+} = require('../dist-electron/main/shared/gigSquareSettlementAsset.js');
 
 test('validateGigSquareServiceMutation rejects missing target service', () => {
   const result = validateGigSquareServiceMutation({
@@ -594,4 +595,129 @@ test('buildGigSquareLocalServiceRecordForModify creates a local overlay row when
   assert.equal(record.displayName, 'Weather Pro');
   assert.equal(record.outputType, 'image');
   assert.equal(record.revokedAt, null);
+});
+
+test('validateGigSquareModifyDraft rejects declared provider skills that are not installed on this host', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [{ id: 'weather', name: 'weather' }],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'provider_skill_not_available');
+  assert.match(result.error, /seedance/);
+});
+
+test('validateGigSquareModifyDraft lists only the missing skills in the availability error', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkills: ['seedance', 'seedream'],
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [{ id: 'seedream', name: 'seedream' }],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'provider_skill_not_available');
+  assert.match(result.error, /seedance/);
+  assert.doesNotMatch(result.error, /seedream/);
+});
+
+test('validateGigSquareModifyDraft accepts declared provider skills that are installed on this host', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [{ id: 'seedance', name: 'seedance' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareModifyDraft matches installed skills by case-insensitive name (runtime parity)', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'Seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [{ id: 'seedance', name: 'seedance' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareModifyDraft matches installed skills by id with _/- normalization (runtime parity)', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'web-search',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [{ id: 'web_search', name: 'Web Search' }],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('validateGigSquareModifyDraft rejects every claim when the host has no installed skills', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  }, {
+    installedSkills: [],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'provider_skill_not_available');
+});
+
+test('validateGigSquareModifyDraft without availability options keeps legacy behavior', () => {
+  const result = validateGigSquareModifyDraft({
+    serviceName: 'svc',
+    displayName: 'SVC',
+    description: 'desc',
+    providerSkill: 'seedance',
+    price: '0',
+    currency: 'SPACE',
+    outputType: 'text',
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('resolveMissingProviderSkills returns only the claims not installed on the host', () => {
+  const missing = resolveMissingProviderSkills(
+    ['seedance', 'weather', 'Seedance'],
+    [{ id: 'weather', name: 'weather' }],
+  );
+
+  assert.deepEqual(missing, ['seedance', 'Seedance']);
 });


### PR DESCRIPTION
## 修复点

服务发布 / 修改路径新增「宿主运行时技能可用性」交叉校验（Issue #10）：

- **发布路径**（`src/main/main.ts` publish RPC）与**修改路径**（modify RPC）在 `validateGigSquareModifyDraft` 校验时传入 `getSkillManager().listSkills()`，将自声明的 `providerSkills` 与宿主真实已安装技能交叉核对。
- **缺失技能拒绝**：声明的技能在本宿主未安装时，发布/修改被拒绝，返回 `errorCode: 'provider_skill_not_available'`，错误信息列出缺失技能名（如 `providerSkill is not available on this host: seedance`）。
- **已安装技能不误拒**：按订单执行时的真实解析语义匹配（`resolveSkillById` 的 `_`/`-` id 变体归一 + `resolveSkillByName` 的大小写不敏感 name 匹配），已安装技能正常放行，既有发布流程无回归。
- **兼容旧调用**：未传 `installedSkills` 的调用方保持原有校验行为（新增可选参数，默认不开启校验）。

## 变更文件

- `src/main/services/gigSquareServiceMutationService.ts`：新增纯函数 `resolveMissingProviderSkills`；`validateGigSquareModifyDraft` 增加可选 `installedSkills` 参数与缺失技能拒绝分支。
- `src/main/main.ts`：发布与修改两条 IPC 路径传入宿主已安装技能列表。
- `tests/gigSquareServiceMutationService.test.mjs`：新增 8 条单测覆盖缺失技能拒绝（含列名）、已安装放行、大小写/`_`-`/`-` 归一匹配、无技能宿主拒绝、旧调用兼容。

## 测试证据

- `node --test tests/gigSquareServiceMutationService.test.mjs`：32 pass / 0 fail（含 8 条新增）。
- 相关 gig-square 回归批次（PublishPresentation / ModifyModalLayout / ProviderPresentation / SkillOptions / MyServicesPresentation）：24 pass / 0 fail。
- 基线：`044741e8`（upstream main，与 Issue 验收锚一致），无上游漂移。

## 边界声明（未执行环节，不自报闭合）

- ⚠️ 未执行 live 冒烟（未启动 Electron 宿主做真实发布/修改端到端验证）——仅单测 + 编译验证。
- ⚠️ 未做链上验证（本修复不涉及链上写入）。
- ⚠️ 未合并 PR（等待 review / CI）。


Closes #10