### PR TITLE
fix: custom providers selectable as LLM brain + deletable in model settings

### DIFF
--- a/src/renderer/components/CustomProviderDeleteConfirmModal.tsx
+++ b/src/renderer/components/CustomProviderDeleteConfirmModal.tsx
@@ -1,0 +1,77 @@
+/**
+ * Custom Provider Delete Confirmation Modal
+ * Confirmation dialog shown before removing a user-created custom LLM provider.
+ * Confirm deletes the provider; cancel closes the dialog without changes.
+ */
+
+import React from 'react';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { i18nService } from '../services/i18n';
+
+export interface CustomProviderDeleteConfirmModalProps {
+  /** Display name of the custom provider being deleted. */
+  name: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const CustomProviderDeleteConfirmModal: React.FC<CustomProviderDeleteConfirmModalProps> = ({
+  name,
+  onClose,
+  onConfirm,
+}) => {
+  const handleDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={i18nService.t('deleteProvider')}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleDialogKeyDown}
+        className="w-full max-w-md rounded-2xl dark:bg-claude-darkSurface bg-claude-bg dark:border-claude-darkBorder border-claude-border border shadow-modal p-4"
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex-shrink-0 w-9 h-9 rounded-full bg-red-500/20 flex items-center justify-center">
+            <ExclamationTriangleIcon className="h-5 w-5 text-red-500" />
+          </div>
+          <div className="min-w-0">
+            <h4 className="text-sm font-semibold dark:text-claude-darkText text-claude-text">
+              {i18nService.t('deleteProvider')}
+            </h4>
+            <p className="mt-1 text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+              {i18nService.t('deleteCustomProviderConfirm').replace('{name}', name)}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover rounded-xl border dark:border-claude-darkBorder border-claude-border"
+          >
+            {i18nService.t('cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-3 py-1.5 text-xs rounded-xl bg-red-600 hover:bg-red-700 text-gray-900 font-medium"
+          >
+            {i18nService.t('delete')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CustomProviderDeleteConfirmModal;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -8,6 +8,7 @@ import { coworkService } from '../services/cowork';
 import { imService } from '../services/im';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
+import CustomProviderDeleteConfirmModal from './CustomProviderDeleteConfirmModal';
 import { XMarkIcon, Cog6ToothIcon, PlusCircleIcon, TrashIcon, PencilIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, ShieldCheckIcon, UserCircleIcon, ArchiveBoxIcon, MoonIcon, ChevronRightIcon, PuzzlePieceIcon, ArrowPathIcon, ExclamationTriangleIcon, BriefcaseIcon, BoltIcon } from '@heroicons/react/24/outline';
 import BrainIcon from './icons/BrainIcon';
 import { CustomProviderIcon, OpenCodeIcon } from './icons/providers';
@@ -519,6 +520,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
   const [customModelName, setCustomModelName] = useState('');
   const [customModelId, setCustomModelId] = useState('');
   const [customProviderError, setCustomProviderError] = useState<string | null>(null);
+  // Pending custom provider scheduled for deletion (holds the confirm dialog open).
+  const [pendingDeleteProvider, setPendingDeleteProvider] = useState<{ key: string; name: string } | null>(null);
 
   const coworkConfig = useSelector((state: RootState) => state.cowork.config);
   const imConfig = useSelector((state: RootState) => state.im.config);
@@ -1971,11 +1974,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
     }
   };
 
+  // Opens the delete confirmation dialog for a custom provider. window.confirm is
+  // blocked by Electron in the renderer, so the dialog is state-driven instead.
   const handleDeleteCustomProvider = (providerKey: string) => {
     const displayName = providers[providerKey]?.name?.trim() || providerKey;
-    if (!window.confirm(i18nService.t('deleteCustomProviderConfirm').replace('{name}', displayName))) {
-      return;
-    }
+    setPendingDeleteProvider({ key: providerKey, name: displayName });
+  };
+
+  // Performs the actual deletion after the user confirms in the dialog.
+  const handleConfirmDeleteCustomProvider = () => {
+    const providerKey = pendingDeleteProvider?.key;
+    if (!providerKey) return;
+    setPendingDeleteProvider(null);
     setProviders(prev => {
       const next = { ...prev };
       delete next[providerKey];
@@ -1987,6 +1997,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
       const firstEnabled = remainingKeys.find(key => visibleProviders[key]?.enabled);
       setActiveProvider((firstEnabled ?? remainingKeys[0]) as ProviderType);
     }
+  };
+
+  const handleCancelDeleteCustomProvider = () => {
+    setPendingDeleteProvider(null);
   };
 
   // 测试 API 连接
@@ -4432,6 +4446,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
                 </div>
               </div>
             </div>
+          )}
+
+          {/* Delete custom provider confirmation */}
+          {pendingDeleteProvider && (
+            <CustomProviderDeleteConfirmModal
+              name={pendingDeleteProvider.name}
+              onClose={handleCancelDeleteCustomProvider}
+              onConfirm={handleConfirmDeleteCustomProvider}
+            />
           )}
 
           {/* Memory Modal */}

--- a/src/renderer/components/metabots/MetabotsManager.tsx
+++ b/src/renderer/components/metabots/MetabotsManager.tsx
@@ -494,13 +494,22 @@ const MetabotsManager: React.FC<MetabotsManagerProps> = ({
 
   const llmOptions = useMemo((): LlmOption[] => {
     const config = configService.getConfig();
-    const providers = (config.providers ?? {}) as Record<string, { enabled?: boolean; apiKey?: string }>;
+    const providers = (config.providers ?? {}) as Record<string, { enabled?: boolean; apiKey?: string; name?: string }>;
     const configured: LlmOption[] = [];
     for (const key of ALL_PROVIDER_KEYS) {
       const p = providers[key];
       if (!p?.enabled) continue;
       if (providerRequiresApiKey(key) && !(p.apiKey ?? '').trim()) continue;
       configured.push({ id: key, label: providerLabel(key) });
+    }
+    // Append user-created custom providers (key prefix `custom-*`), which are
+    // not part of the built-in ALL_PROVIDER_KEYS registry. Prefer the configured
+    // display name and fall back to the derived provider label.
+    for (const [key, p] of Object.entries(providers)) {
+      if ((ALL_PROVIDER_KEYS as readonly string[]).includes(key)) continue;
+      if (!p?.enabled) continue;
+      if (providerRequiresApiKey(key) && !(p.apiKey ?? '').trim()) continue;
+      configured.push({ id: key, label: p.name?.trim() || providerLabel(key) });
     }
     return configured;
   }, [settingsClosedTrigger]);


### PR DESCRIPTION
## Summary

Two bug fixes for user-created custom LLM providers, both found by real-world testing on v0.4.6.

### Bug A — Custom providers missing from the "LLM brain" dropdown

**Reproduction:** Add a custom provider (e.g. key `custom-opencode-2`) in Model settings with an API key and enabled, then open the add/edit MetaBot form and expand the LLM model dropdown. The custom provider is absent.

**Root cause:** `llmOptions` in `MetabotsManager.tsx` only iterated the hard-coded `ALL_PROVIDER_KEYS` list, so any provider key outside the built-in registry (`custom-*`) was silently dropped.

**Fix:** After the built-in providers, iterate `Object.entries(config.providers)` and append any key not in `ALL_PROVIDER_KEYS` that is enabled and passes the same `providerRequiresApiKey` check. The display label prefers the configured `name` field and falls back to the derived `providerLabel`. Built-in providers keep their position first; custom providers are appended after.

### Bug B — Delete button on a custom provider did nothing

**Reproduction:** In Model settings, hover a custom provider and click the trash icon. Nothing happens.

**Root cause:** `handleDeleteCustomProvider` used `window.confirm`, which is blocked (always returns `false`) in the Electron renderer, so the handler returned early and never deleted.

**Fix:** Replaced `window.confirm` with a React state-driven confirmation dialog (`CustomProviderDeleteConfirmModal`, modeled after `MetaBotDeleteConfirmModal`). Clicking delete now opens the dialog; confirming performs the existing deletion logic (state removal, clearing the test result, falling back `activeProvider`); cancelling closes without deleting. No `window.confirm`/`window.alert` remains in the affected scope.

## Verification

- `npm run compile:electron` — 0 errors
- renderer type-check (`tsc --project tsconfig.json`) — 0 errors
- `npm run build:skills` — 0 errors
- `npm run lint` on the changed files — clean (full-repo lint reports 3 pre-existing unused-eslint-disable errors in files untouched by this PR)
- `node --test tests/*.test.mjs` — 1928 pass / 180 fail; all failures are pre-existing on the base (main-process tests import `../dist-electron/services/*`, which the current build emits under `dist-electron/main/services/*`). This PR only touches renderer code, which the node test suite does not exercise.
