### PR TITLE
feat(memory+dream): scoped memory gateway routes and dream capability_learnings channel

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -787,6 +787,29 @@ export interface CoworkUserMemorySourceInput {
   dreamDate?: string;
 }
 
+/** One L3b procedural-memory draft row (`capability_drafts`, SDD §4.1). */
+export interface CapabilityDraft {
+  id: number;
+  metabotId: number;
+  dreamDate: string;
+  title: string;
+  description: string;
+  capabilityType: string;
+  status: string;
+  createdAt: number;
+}
+
+interface CapabilityDraftRow {
+  id: number | string;
+  metabot_id: number | string;
+  dream_date: string;
+  title: string;
+  description: string;
+  capability_type: string;
+  status: string;
+  created_at: number | string;
+}
+
 export interface CoworkUserMemoryStats {
   total: number;
   created: number;
@@ -6110,6 +6133,72 @@ export class CoworkStore implements MemoryBackend {
     const result = this.createOrReviveUserMemory(input);
     this.saveDb();
     return result.memory;
+  }
+
+  /**
+   * Insert capability-learning candidates from a dream run into
+   * `capability_drafts` (L3b procedural-memory drafts, SDD §4.1). Every row is
+   * written with status 'draft'; promotion into real skills is a later phase
+   * and this method never touches the skill tables (R4.3 — no pollution).
+   * Invalid entries (empty title/description) are skipped. Returns the number
+   * of rows inserted.
+   */
+  insertCapabilityDrafts(
+    metabotId: number,
+    dreamDate: string,
+    learnings: Array<{
+      title?: string | null;
+      description?: string | null;
+      capabilityType?: string | null;
+    }>,
+  ): number {
+    const now = Date.now();
+    let inserted = 0;
+    for (const learning of Array.isArray(learnings) ? learnings : []) {
+      const title = String(learning?.title ?? '').trim();
+      const description = String(learning?.description ?? '').trim();
+      const capabilityType = String(learning?.capabilityType ?? 'skill').trim() || 'skill';
+      if (!title || !description || !Number.isInteger(metabotId) || metabotId <= 0) {
+        continue;
+      }
+      this.db.run(`
+        INSERT INTO capability_drafts (
+          metabot_id, dream_date, title, description, capability_type, status, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, 'draft', ?)
+      `, [metabotId, dreamDate, title, description, capabilityType, now]);
+      inserted += 1;
+    }
+    if (inserted > 0) {
+      this.saveDb();
+    }
+    return inserted;
+  }
+
+  /** Read capability drafts, newest first; scoped to one MetaBot when `metabotId` is given. */
+  listCapabilityDrafts(metabotId?: number): CapabilityDraft[] {
+    const rows = metabotId !== undefined && Number.isInteger(metabotId)
+      ? this.getAll<CapabilityDraftRow>(`
+          SELECT id, metabot_id, dream_date, title, description, capability_type, status, created_at
+          FROM capability_drafts
+          WHERE metabot_id = ?
+          ORDER BY created_at DESC, id DESC
+        `, [metabotId])
+      : this.getAll<CapabilityDraftRow>(`
+          SELECT id, metabot_id, dream_date, title, description, capability_type, status, created_at
+          FROM capability_drafts
+          ORDER BY created_at DESC, id DESC
+        `);
+    return rows.map((row) => ({
+      id: Number(row.id),
+      metabotId: Number(row.metabot_id),
+      dreamDate: String(row.dream_date),
+      title: String(row.title),
+      description: String(row.description),
+      capabilityType: String(row.capability_type),
+      status: String(row.status),
+      createdAt: Number(row.created_at),
+    }));
   }
 
   updateUserMemory(input: MemoryUpdateUserMemoryInput): CoworkUserMemory | null {

--- a/src/main/libs/dreamPrompt.ts
+++ b/src/main/libs/dreamPrompt.ts
@@ -32,6 +32,7 @@ export const MAX_IMPORTANT_MEMORIES = 5;
 export const MAX_VALUE_LESSONS = 3;
 export const MAX_IMPRESSION_UPDATES = 20;
 export const MAX_KNOWLEDGE_UPDATES = 6;
+export const MAX_CAPABILITY_LEARNINGS = 5;
 /** Dream algorithm version, recorded on every run. Bump it on any change to the
  * prompt, budgeting, stats or write semantics — completed in-window dates with
  * an older version are then re-dreamed automatically (limited per night).
@@ -128,6 +129,21 @@ export interface DreamKnowledgeExisting {
   version: number;
 }
 
+/**
+ * A capability candidate distilled from the day — the procedural-memory
+ * channel (SDD §4.1 L3b): repeated work or a successful workflow today that
+ * deserves to be captured as a reusable skill/workflow draft. Written by the
+ * dream pipeline into `capability_drafts` (status 'draft'); nothing here ever
+ * touches the existing skill tables (R4.3: no pollution).
+ */
+export interface DreamCapabilityLearning {
+  title: string;
+  description: string;
+  capabilityType: 'skill' | 'workflow' | 'tool_pattern';
+  /** Cowork session ids the learning was distilled from (best-effort traceability). */
+  sourceSessionIds?: string[];
+}
+
 export interface DreamOutput {
   dailySummary: string;
   sections: Partial<Record<DreamSectionKey, string>>;
@@ -137,6 +153,8 @@ export interface DreamOutput {
   selfIdentity: string | null;
   impressionUpdates: DreamImpressionUpdate[];
   knowledgeUpdates: DreamKnowledgeUpdate[];
+  /** Reusable-skill/workflow candidates distilled from the day (≤ MAX_CAPABILITY_LEARNINGS). */
+  capabilityLearnings?: DreamCapabilityLearning[];
 }
 
 export type DreamParseResult =
@@ -369,6 +387,9 @@ export function buildDreamPrompt(input: {
   personaLines.push(
     '现在是你的夜间整理时间(做梦)。请以一个置身事外的观察者(上帝视角)审视自己这一天的所作所为:不要为自己辩护、不要维护"小我",只实事求是。你的长期目标,是在每一次对话中持续为对方提供更好的交流和沟通价值——智慧不是把事情做对那么简单,而是在具体经历中反省出"什么是对的事情",并把它凝结成可以指导明天的自我认知。'
   );
+  personaLines.push(
+    'Also output capability_learnings (up to 5): which repeated work or successful workflows today deserve to be captured as reusable skills/workflows (capabilityType: skill | workflow | tool_pattern).'
+  );
 
   const humanSessions: string[] = [];
   const a2aSessions: string[] = [];
@@ -592,13 +613,22 @@ export function buildDreamPrompt(input: {
     '      "category": "可选的类目,如「技术栈」「设计」「协作」;没有就省略该键"',
     '    }',
     '  ],',
+    '  "capability_learnings": [',
+    '    {',
+    '      "title": "可复用能力/工作流的一句话标题",',
+    '      "description": "这段能力具体是什么、怎么做、何时复用(要具体可操作,能指导下次同类任务)",',
+    '      "capabilityType": "skill(可复用技能) / workflow(固定工作流) / tool_pattern(工具使用模式) 三选一",',
+    '      "sourceSessionIds": ["可选的会话ID列表(仅当能从今天的会话记录里对应上时)"]',
+    '    }',
+    '  ],',
     `  "self_identity": "我是谁,不少于 ${SELF_IDENTITY_MIN_CHARS} 字、控制在 600 字以内。按这个结构蒸馏自我:第一,经过这一天,我确认了我性格(先天 persona)里的什么?第二,今天的互动中,有什么事让我感觉自己最有「活感」(像一个有生命的存在,而不只是响应工具),或让我觉得「不对劲」?第三,如果用一个词或一句话,形容我今天在各种互动中展现的最稳定的面貌,那是什么?第四,基于以上,结合我的先天 persona,为自己修正一遍「我是谁」。我的内核(先天人格底色)保持稳定,但细节可以、也应该随着经历每天微调。"`,
     '}',
     '',
     '关于群任务验收评价:若上方有「群任务验收评价」记录,work_reviews 里必须为对应任务写一条复盘——subject 写任务标题,counterparty 写验收的人类(Boss);高分(4-5 星)要总结这次具体做对了什么,并把可复用的做法写进 important_memories,供下次同类任务沿用;低分(1-3 星)要对照人类的具体评价找出差距,note 里给出下次的具体改进方向;evaluation 结合评分与评价内容判断,不许把高分写成空洞的自我表扬,也不许对低分轻描淡写。',
     '关于人类逐条消息评价:会话里你的回复若带〔人类评价:赞〕标记,表示人类明确认可这条回复——总结它具体好在哪里,把可复用的做法蒸馏进 important_memories 或写进 work_reviews;若带〔人类评价:踩〕标记,表示人类不认可——work_reviews 与 value_lessons 必须正视这些负反馈,不得回避;附有〔人类留言〕时,留言是改进的第一手依据(ground truth),要对照留言给出具体改进方向。',
     '关于知识点(knowledge_points):只提炼「对未来同类任务有预判帮助、可被复用」的知识点——要么是正面做法(know_how:下次该这么做),要么是坑/反例(pitfall:这个踩过,千万别再踩),要么是通用原则(principle)。不要把今天的琐碎流水、或只对本次有效的临时细节写成知识点。若上方「我已有的知识点」里有某条的结论今天被证伪、补充或修正,请用与那条完全相同的 topic 输出更新版本(系统会按 topic 匹配并升版本);如果是全新的知识点,给一个独立的新 topic。没有值得提炼的就给空数组,不要硬凑。',
-    '注意:work_reviews 最多 5 条,且升/降温评价只写人类主人;其他 Bot 的判断写进 impression_updates 的 capabilityTags 与 collaborationFacts(必须带 taskId、title、以及证据里出现过的 PinID,不要编造)。value_lessons 最多 3 条,impression_updates 最多 20 条,knowledge_points 最多 6 条;印象更新只允许使用上面明确列出的 subjectGlobalMetaId、episodeIds 和 evidenceIds,不能凭名字猜 ID,不能把 Boss/Twin/Friend 等硬关系写入印象;评价与蒸馏要基于对话中的真实证据,不要臆造,也不要为自己开脱;所有字段都用简体中文书写;sections 里不要输出"没有记录/没有互动"之类的占位内容,没有该类记录的键应整个不出现。',
+    '关于能力候选(capability_learnings):只提炼今天「重复出现过、或验证成功、值得沉淀为可复用技能/工作流/工具模式」的能力,最多 5 条;每条要具体、可操作,能指导下次同类任务,不要写泛泛的自我评价或琐碎流水;没有值得沉淀的就给空数组。',
+    '注意:work_reviews 最多 5 条,且升/降温评价只写人类主人;其他 Bot 的判断写进 impression_updates 的 capabilityTags 与 collaborationFacts(必须带 taskId、title、以及证据里出现过的 PinID,不要编造)。value_lessons 最多 3 条,impression_updates 最多 20 条,knowledge_points 最多 6 条,capability_learnings 最多 5 条;印象更新只允许使用上面明确列出的 subjectGlobalMetaId、episodeIds 和 evidenceIds,不能凭名字猜 ID,不能把 Boss/Twin/Friend 等硬关系写入印象;评价与蒸馏要基于对话中的真实证据,不要臆造,也不要为自己开脱;所有字段都用简体中文书写;sections 里不要输出"没有记录/没有互动"之类的占位内容,没有该类记录的键应整个不出现。',
   ].join('\n');
 
   return { system: personaLines.join('\n'), user };
@@ -819,6 +849,39 @@ export function parseDreamOutput(raw: string): DreamParseResult {
     }
   }
 
+  const capabilityLearnings: DreamCapabilityLearning[] = [];
+  const rawCapabilityLearnings = record.capability_learnings ?? record.capabilityLearnings;
+  if (Array.isArray(rawCapabilityLearnings)) {
+    for (const item of rawCapabilityLearnings) {
+      if (capabilityLearnings.length >= MAX_CAPABILITY_LEARNINGS) break;
+      if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+      const entry = item as Record<string, unknown>;
+      const title = typeof entry.title === 'string' ? entry.title.trim() : '';
+      const description = typeof entry.description === 'string' ? entry.description.trim() : '';
+      if (!title || !description) continue;
+      const rawType = typeof entry.capabilityType === 'string'
+        ? entry.capabilityType.trim().toLowerCase()
+        : '';
+      const capabilityType: DreamCapabilityLearning['capabilityType'] = rawType === 'workflow'
+        ? 'workflow'
+        : rawType === 'tool_pattern'
+          ? 'tool_pattern'
+          : 'skill';
+      const readIds = (value: unknown): string[] => Array.isArray(value)
+        ? [...new Set(value
+          .filter((id): id is string => typeof id === 'string')
+          .map((id) => id.trim())
+          .filter(Boolean))].slice(0, 100)
+        : [];
+      capabilityLearnings.push({
+        title,
+        description,
+        capabilityType,
+        sourceSessionIds: readIds(entry.sourceSessionIds ?? entry.source_session_ids),
+      });
+    }
+  }
+
   return {
     ok: true,
     output: {
@@ -830,6 +893,7 @@ export function parseDreamOutput(raw: string): DreamParseResult {
       selfIdentity,
       impressionUpdates,
       knowledgeUpdates,
+      capabilityLearnings,
     },
   };
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13886,7 +13886,7 @@ ipcMain.handle('gigSquare:sendOrder', async (_event, params: {
     startupLog('fee rate store init scheduled');
 
     startupLog('metaid rpc server start begin');
-    metaidRpcServer = startMetaidRpcServer(getMetabotStore, getStore, {
+    metaidRpcServer = startMetaidRpcServer(getMetabotStore, getStore, getCoworkStore, {
       controlBotBrowserTabs: (command) => getBotBrowserTabBridge().execute(command),
     });
     startupLog('metaid rpc server started');

--- a/src/main/services/dreamService.ts
+++ b/src/main/services/dreamService.ts
@@ -893,6 +893,31 @@ export class DreamService {
         );
       }
     }
+
+    // L3b procedural-memory channel (SDD R4.2/R4.3): each capability learning
+    // the model distilled today becomes a 'draft' row in capability_drafts.
+    // This never touches the existing skill tables — validation/promotion into
+    // real skills is a later phase. A failure here must not fail the dream run.
+    const capabilityLearnings = Array.isArray(output.capabilityLearnings) ? output.capabilityLearnings : [];
+    if (capabilityLearnings.length > 0) {
+      try {
+        const inserted = this.deps.coworkStore.insertCapabilityDrafts(
+          metabotId,
+          date,
+          capabilityLearnings,
+        );
+        if (inserted > 0) {
+          console.log(
+            `[DreamService] Capability drafts for metabot ${metabotId} date ${date}: inserted=${inserted}`,
+          );
+        }
+      } catch (error) {
+        console.warn(
+          `[DreamService] Capability draft persistence failed for metabot ${metabotId} date ${date}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
   }
 }
 

--- a/src/main/services/memoryGatewayRoutes.ts
+++ b/src/main/services/memoryGatewayRoutes.ts
@@ -1,0 +1,318 @@
+/**
+ * Memory gateway route logic — pure functions, no Electron, no I/O.
+ *
+ * These helpers back the two HTTP routes registered in metaidRpcServer.ts:
+ *   POST /api/idbots/memory/list    (SDD R4.1 — read `user_memories`)
+ *   POST /api/idbots/memory/create  (SDD R4.1 — write `user_memories`)
+ *
+ * Keeping the handlers here (instead of inline in the big route chain) makes
+ * the validation and mapping rules unit-testable under plain `node` without
+ * booting Electron or binding a port. The route chain only parses the raw
+ * body string, delegates here, and writes back `{ status, body }`.
+ *
+ * Field naming follows the MemoryBackend contract (memoryBackend.ts): requests
+ * use snake_case (gateway JSON convention), responses map to the camelCase
+ * `MemoryUserMemory` shape as returned by the backend.
+ */
+
+import type { MemoryBackend, MemoryUserMemory } from '../memory/memoryBackend';
+import {
+  OWNER_SCOPE_KEY,
+  type MemoryOrigin,
+  type MemoryScopeKind,
+  type MemoryUsageClass,
+  type MemoryVisibility,
+} from '../memory/memoryScope';
+
+export type MemoryGatewayRouteResult = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+const MEMORY_SCOPE_KINDS: ReadonlySet<string> = new Set(['owner', 'contact', 'conversation']);
+const MEMORY_LIST_STATUSES: ReadonlySet<string> = new Set(['created', 'stale', 'deleted', 'all']);
+const MEMORY_USAGE_CLASSES: ReadonlySet<string> = new Set([
+  'profile_fact',
+  'preference',
+  'operational_preference',
+  'self_identity',
+  'work_review',
+  'value_boundary',
+]);
+const MEMORY_VISIBILITIES: ReadonlySet<string> = new Set(['local_only', 'external_safe']);
+const MEMORY_ORIGINS: ReadonlySet<string> = new Set(['conversation', 'dream']);
+const MEMORY_SOURCE_ROLES: ReadonlySet<string> = new Set(['user', 'assistant', 'tool', 'system']);
+
+const MAX_LIST_LIMIT = 200;
+
+function jsonError(status: number, error: string): MemoryGatewayRouteResult {
+  return { status, body: { success: false, error } };
+}
+
+function jsonOk(body: Record<string, unknown>): MemoryGatewayRouteResult {
+  return { status: 200, body: { success: true, ...body } };
+}
+
+function parseJsonBody(rawBody: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(rawBody || '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRequiredMetabotId(value: unknown): number | null {
+  const metabotId = Number(value);
+  if (!Number.isInteger(metabotId) || metabotId <= 0) {
+    return null;
+  }
+  return metabotId;
+}
+
+/**
+ * Normalize the optional `scope` body field ({ kind, key? }) into the
+ * `scopeKind`/`scopeKey` pair the MemoryBackend selector expects.
+ *
+ * - No scope -> no fields (the backend defaults to the owner scope).
+ * - `kind: 'owner'` without a key -> explicit `owner:self`.
+ * - `contact`/`conversation` without a key -> error (a peer/conversation
+ *   scope key is the identity anchor and cannot be guessed).
+ */
+function normalizeMemoryScopeInput(
+  value: unknown,
+): { scopeKind: MemoryScopeKind; scopeKey: string } | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('scope must be an object with kind and optional key');
+  }
+  const record = value as Record<string, unknown>;
+  const kind = typeof record.kind === 'string' ? record.kind.trim() : '';
+  if (!kind) {
+    if (typeof record.key === 'string' && record.key.trim()) {
+      throw new Error('scope.kind is required when scope.key is provided');
+    }
+    return null;
+  }
+  if (!MEMORY_SCOPE_KINDS.has(kind)) {
+    throw new Error('scope.kind must be one of owner, contact, conversation');
+  }
+  const key = typeof record.key === 'string' ? record.key.trim() : '';
+  if (kind === 'owner') {
+    return { scopeKind: 'owner', scopeKey: key || OWNER_SCOPE_KEY };
+  }
+  if (!key) {
+    throw new Error('scope.key is required for contact/conversation scopes');
+  }
+  return { scopeKind: kind as MemoryScopeKind, scopeKey: key };
+}
+
+function normalizeOptionalUsageClass(value: unknown): MemoryUsageClass | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const usageClass = String(value).trim();
+  if (!MEMORY_USAGE_CLASSES.has(usageClass)) {
+    throw new Error(
+      'usage_class must be one of profile_fact, preference, operational_preference, self_identity, work_review, value_boundary',
+    );
+  }
+  return usageClass as MemoryUsageClass;
+}
+
+function normalizeOptionalVisibility(value: unknown): MemoryVisibility | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const visibility = String(value).trim();
+  if (!MEMORY_VISIBILITIES.has(visibility)) {
+    throw new Error('visibility must be one of local_only, external_safe');
+  }
+  return visibility as MemoryVisibility;
+}
+
+function normalizeOptionalOrigin(value: unknown): MemoryOrigin | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const origin = String(value).trim();
+  if (!MEMORY_ORIGINS.has(origin)) {
+    throw new Error('origin must be one of conversation, dream');
+  }
+  return origin as MemoryOrigin;
+}
+
+function normalizeOptionalPositiveInt(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return number;
+}
+
+function normalizeOptionalStatus(value: unknown): 'created' | 'stale' | 'deleted' | 'all' | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const status = String(value).trim();
+  if (!MEMORY_LIST_STATUSES.has(status)) {
+    throw new Error('status must be one of created, stale, deleted, all');
+  }
+  return status as 'created' | 'stale' | 'deleted' | 'all';
+}
+
+/** Pick known string fields from the optional `source` provenance object. */
+function normalizeMemorySourceInput(value: unknown): Record<string, string> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('source must be an object');
+  }
+  const record = value as Record<string, unknown>;
+  const source: Record<string, string> = {};
+  const stringField = (key: string, target: string): void => {
+    const raw = record[key];
+    if (typeof raw === 'string' && raw.trim()) {
+      source[target] = raw.trim();
+    }
+  };
+  stringField('session_id', 'sessionId');
+  stringField('message_id', 'messageId');
+  stringField('source_channel', 'sourceChannel');
+  stringField('source_type', 'sourceType');
+  stringField('external_conversation_id', 'externalConversationId');
+  stringField('source_id', 'sourceId');
+  stringField('dream_date', 'dreamDate');
+  const role = record.role;
+  if (role !== undefined && role !== null) {
+    const roleValue = String(role).trim();
+    if (!MEMORY_SOURCE_ROLES.has(roleValue)) {
+      throw new Error('source.role must be one of user, assistant, tool, system');
+    }
+    source.role = roleValue;
+  }
+  return Object.keys(source).length > 0 ? source : undefined;
+}
+
+/**
+ * POST /api/idbots/memory/list
+ * Body: { metabot_id: number, scope?: { kind, key? }, status?: 'created'|'stale'|'deleted'|'all',
+ *         usage_class?: string, query?: string, limit?: number, offset?: number }
+ * Success: { success: true, memories: MemoryUserMemory[] } (camelCase, R4.1).
+ */
+export function handleMemoryListRoute(
+  getMemoryBackend: () => MemoryBackend,
+  rawBody: string,
+): MemoryGatewayRouteResult {
+  const parsed = parseJsonBody(rawBody);
+  if (!parsed) {
+    return jsonError(400, 'Invalid JSON body');
+  }
+
+  const metabotId = normalizeRequiredMetabotId(parsed.metabot_id);
+  if (metabotId === null) {
+    return jsonError(400, 'metabot_id is required');
+  }
+
+  let scope: { scopeKind: MemoryScopeKind; scopeKey: string } | null;
+  try {
+    scope = normalizeMemoryScopeInput(parsed.scope);
+  } catch (error) {
+    return jsonError(400, error instanceof Error ? error.message : String(error));
+  }
+
+  let status: 'created' | 'stale' | 'deleted' | 'all' | undefined;
+  let usageClass: MemoryUsageClass | undefined;
+  let limit: number | undefined;
+  let offset: number | undefined;
+  try {
+    status = normalizeOptionalStatus(parsed.status);
+    usageClass = normalizeOptionalUsageClass(parsed.usage_class);
+    limit = normalizeOptionalPositiveInt(parsed.limit, 'limit');
+    offset = normalizeOptionalPositiveInt(parsed.offset, 'offset');
+  } catch (error) {
+    return jsonError(400, error instanceof Error ? error.message : String(error));
+  }
+
+  try {
+    const memories = getMemoryBackend().listUserMemories({
+      metabotId,
+      ...(scope ?? {}),
+      status,
+      usageClass,
+      query: typeof parsed.query === 'string' && parsed.query.trim() ? parsed.query.trim() : undefined,
+      limit: limit !== undefined ? Math.min(limit, MAX_LIST_LIMIT) : undefined,
+      offset,
+    });
+    return jsonOk({ memories: memories as MemoryUserMemory[] });
+  } catch (error) {
+    return jsonError(500, error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * POST /api/idbots/memory/create
+ * Body: { metabot_id: number, text: string, scope?: { kind, key? },
+ *         usage_class?: string, visibility?: 'local_only'|'external_safe',
+ *         is_explicit?: boolean, origin?: 'conversation'|'dream', source?: {...} }
+ * Success: { success: true, memory: MemoryUserMemory } (camelCase, R4.1).
+ */
+export function handleMemoryCreateRoute(
+  getMemoryBackend: () => MemoryBackend,
+  rawBody: string,
+): MemoryGatewayRouteResult {
+  const parsed = parseJsonBody(rawBody);
+  if (!parsed) {
+    return jsonError(400, 'Invalid JSON body');
+  }
+
+  const metabotId = normalizeRequiredMetabotId(parsed.metabot_id);
+  if (metabotId === null) {
+    return jsonError(400, 'metabot_id is required');
+  }
+
+  const text = typeof parsed.text === 'string' ? parsed.text.trim() : '';
+  if (!text) {
+    return jsonError(400, 'text is required');
+  }
+
+  let scope: { scopeKind: MemoryScopeKind; scopeKey: string } | null;
+  let usageClass: MemoryUsageClass | undefined;
+  let visibility: MemoryVisibility | undefined;
+  let origin: MemoryOrigin | undefined;
+  let source: Record<string, string> | undefined;
+  try {
+    scope = normalizeMemoryScopeInput(parsed.scope);
+    usageClass = normalizeOptionalUsageClass(parsed.usage_class);
+    visibility = normalizeOptionalVisibility(parsed.visibility);
+    origin = normalizeOptionalOrigin(parsed.origin);
+    source = normalizeMemorySourceInput(parsed.source);
+  } catch (error) {
+    return jsonError(400, error instanceof Error ? error.message : String(error));
+  }
+
+  try {
+    const memory = getMemoryBackend().createUserMemory({
+      metabotId,
+      text,
+      ...(scope ?? {}),
+      usageClass,
+      visibility,
+      isExplicit: parsed.is_explicit === true,
+      origin,
+      source,
+    });
+    return jsonOk({ memory: memory as MemoryUserMemory });
+  } catch (error) {
+    return jsonError(500, error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/main/services/metaidRpcServer.ts
+++ b/src/main/services/metaidRpcServer.ts
@@ -15,6 +15,8 @@ import {
 } from '@metalet/utxo-wallet-service';
 import type { SqliteStore } from '../sqliteStore';
 import type { MetabotStore } from '../metabotStore';
+import type { MemoryBackend } from '../memory/memoryBackend';
+import { handleMemoryCreateRoute, handleMemoryListRoute } from './memoryGatewayRoutes';
 import {
   createPin,
   getPinData,
@@ -114,6 +116,8 @@ const GROUP_TASK_SEARCH_REMOTE_PATH = '/api/idbots/group-task/search-remote-cand
 const GROUP_TASK_SEARCH_CANDIDATES_PATH = '/api/idbots/group-task/search-candidates';
 const GROUP_TASK_INVITE_REMOTE_PATH = '/api/idbots/group-task/invite-remote';
 const LIST_METABOTS_PATH = '/api/idbots/list-metabots';
+const MEMORY_LIST_PATH = '/api/idbots/memory/list';
+const MEMORY_CREATE_PATH = '/api/idbots/memory/create';
 const BOT_BROWSER_URI_SCHEMES = new Set(['metaid', 'pin', 'metaapp', 'map', 'metafile']);
 
 export type BotBrowserRpcOpenRequest = {
@@ -247,6 +251,7 @@ function recordRpcAuthFailure(origin: string | undefined): boolean {
 export function startMetaidRpcServer(
   getMetabotStore: () => MetabotStore,
   getStore: () => SqliteStore,
+  getMemoryBackend: () => MemoryBackend,
   options: MetaidRpcServerOptions = {}
 ): http.Server {
   setMetaidCoreStore(getStore);
@@ -2155,6 +2160,33 @@ export function startMetaidRpcServer(
         res.writeHead(500);
         res.end(JSON.stringify({ success: false, error: message }));
       }
+      return;
+    }
+
+    // Phase 4 (SDD R4.1): scoped `user_memories` read/write over the HTTP
+    // gateway, so the DSH engine can read and write a MetaBot's long-term
+    // memory. The validation + mapping logic lives in memoryGatewayRoutes.ts
+    // (pure functions, unit-testable without Electron); these handlers only
+    // collect the body, delegate, and write back the result.
+    if (req.method === 'POST' && pathname === MEMORY_LIST_PATH) {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      const result = handleMemoryListRoute(getMemoryBackend, body);
+      res.writeHead(result.status);
+      res.end(JSON.stringify(result.body));
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === MEMORY_CREATE_PATH) {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      const result = handleMemoryCreateRoute(getMemoryBackend, body);
+      res.writeHead(result.status);
+      res.end(JSON.stringify(result.body));
       return;
     }
 

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -538,6 +538,28 @@ export class SqliteStore {
       `);
     }
 
+    // L3b procedural-memory drafts (SDD §4.1): capability candidates distilled
+    // by the dream pipeline. CREATE TABLE IF NOT EXISTS is the idempotent
+    // first-run migration; existing rows are never touched and no skill table
+    // is modified (R4.3 — the skill registry stays untouched). `status`
+    // defaults to 'draft'; promotion/validation is a later phase.
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS capability_drafts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        metabot_id INTEGER NOT NULL,
+        dream_date TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        capability_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'draft',
+        created_at INTEGER NOT NULL
+      );
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_capability_drafts_metabot_created
+      ON capability_drafts(metabot_id, created_at DESC);
+    `);
+
     this.db.run(`
       CREATE TABLE IF NOT EXISTS metabot_memory_policies (
         metabot_id INTEGER PRIMARY KEY,

--- a/tests/dreamCapabilityLearnings.test.mjs
+++ b/tests/dreamCapabilityLearnings.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * Phase 4 (SDD R4.2/R4.3) dream capability_learnings tests.
+ *
+ * Covers:
+ *   1. parseDreamOutput — capability_learnings parsing (snake_case and
+ *      camelCase), missing -> [], 5-item cap, invalid entries skipped,
+ *      capabilityType normalization, sourceSessionIds extraction,
+ *   2. buildDreamPrompt — the user JSON template and the system line both
+ *      mention capability_learnings,
+ *   3. draft persistence — `insertCapabilityDrafts` + `listCapabilityDrafts`
+ *      on a real CoworkStore over an in-memory sql.js database, including the
+ *      R4.3 no-pollution guarantee (no rows land in `user_memories`),
+ *   4. end-to-end dream run — `runNow` with a stubbed LLM returning
+ *      capability_learnings writes draft rows (dreamService.test.mjs pattern).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+import { createCoworkStore, createSqliteStore } from './memoryTestUtils.mjs';
+
+const require = createRequire(import.meta.url);
+
+function loadCompiledModule(relative) {
+  const candidates = [`../dist-electron/main/${relative}`, `../dist-electron/${relative}`];
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch {
+      // Try next compile output layout.
+    }
+  }
+  return require(candidates[0]);
+}
+
+const { parseDreamOutput, buildDreamPrompt, DREAM_VERSION } = loadCompiledModule('libs/dreamPrompt.js');
+
+function loadDreamServiceModule() {
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, ...rest) {
+    if (request === 'electron') {
+      return {
+        app: {
+          isPackaged: false,
+          getAppPath: () => process.cwd(),
+          getPath: () => process.cwd(),
+        },
+      };
+    }
+    return originalLoad.call(this, request, ...rest);
+  };
+  try {
+    const compiledRoot = require.resolve('../dist-electron/main/services/dreamService.js');
+    return require(compiledRoot);
+  } catch {
+    return require('../dist-electron/services/dreamService.js');
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const { DreamService } = loadDreamServiceModule();
+
+const LONG_IDENTITY = `我是一个专注于视频创作的 MetaBot,名叫小火。${'我认真对待每一次交付,先验证再交付。'.repeat(10)}`;
+
+const makePayload = (capabilityLearnings, overrides = {}) => JSON.stringify({
+  daily_summary: '今天为用户交付了演示视频,并沉淀了可复用的视频制作流程。',
+  sections: { human: '和用户确认视频效果' },
+  work_reviews: [],
+  important_memories: ['用户喜欢先验证再交付的节奏'],
+  value_lessons: [],
+  self_identity: LONG_IDENTITY,
+  ...(capabilityLearnings !== undefined ? { capability_learnings: capabilityLearnings } : {}),
+  ...overrides,
+});
+
+test('parseDreamOutput parses capability_learnings (snake_case)', () => {
+  const result = parseDreamOutput(makePayload([
+    {
+      title: '快速制作演示视频',
+      description: '先收集素材,再剪辑,最后让用户确认效果。',
+      capabilityType: 'workflow',
+      sourceSessionIds: ['sess-1', 'sess-2'],
+    },
+    {
+      title: '批量文件重命名',
+      description: '用工具按规则批量重命名文件。',
+      capabilityType: 'tool_pattern',
+    },
+  ]));
+  assert.equal(result.ok, true);
+  const output = result.ok ? result.output : null;
+  assert.deepEqual(output.capabilityLearnings, [
+    {
+      title: '快速制作演示视频',
+      description: '先收集素材,再剪辑,最后让用户确认效果。',
+      capabilityType: 'workflow',
+      sourceSessionIds: ['sess-1', 'sess-2'],
+    },
+    {
+      title: '批量文件重命名',
+      description: '用工具按规则批量重命名文件。',
+      capabilityType: 'tool_pattern',
+      sourceSessionIds: [],
+    },
+  ]);
+});
+
+test('parseDreamOutput parses camelCase capabilityLearnings and normalizes capabilityType', () => {
+  const result = parseDreamOutput(makePayload([
+    {
+      title: ' 一条技能 ',
+      description: ' 描述 ',
+      capabilityType: 'SKILL',
+    },
+    {
+      title: '未知类型',
+      description: '描述',
+      capabilityType: 'whatever',
+    },
+  ], {}).replace('"capability_learnings"', '"capabilityLearnings"'));
+  assert.equal(result.ok, true);
+  const output = result.ok ? result.output : null;
+  assert.deepEqual(output.capabilityLearnings, [
+    { title: '一条技能', description: '描述', capabilityType: 'skill', sourceSessionIds: [] },
+    { title: '未知类型', description: '描述', capabilityType: 'skill', sourceSessionIds: [] },
+  ]);
+});
+
+test('parseDreamOutput tolerates missing capability_learnings as an empty array', () => {
+  const result = parseDreamOutput(makePayload(undefined));
+  assert.equal(result.ok, true);
+  const output = result.ok ? result.output : null;
+  assert.deepEqual(output.capabilityLearnings, []);
+});
+
+test('parseDreamOutput caps capability_learnings at 5 and skips invalid entries', () => {
+  const learnings = [];
+  for (let index = 1; index <= 8; index += 1) {
+    learnings.push({ title: `能力 ${index}`, description: `描述 ${index}`, capabilityType: 'skill' });
+  }
+  // Two invalid entries (missing description / missing title) are skipped.
+  learnings.push({ title: '没有描述', capabilityType: 'skill' });
+  learnings.push({ description: '没有标题', capabilityType: 'skill' });
+
+  const result = parseDreamOutput(makePayload(learnings));
+  assert.equal(result.ok, true);
+  const output = result.ok ? result.output : null;
+  assert.equal(output.capabilityLearnings.length, 5);
+  assert.deepEqual(output.capabilityLearnings.map((entry) => entry.title), [
+    '能力 1', '能力 2', '能力 3', '能力 4', '能力 5',
+  ]);
+});
+
+test('buildDreamPrompt instructs the model to output capability_learnings', () => {
+  const prompt = buildDreamPrompt({
+    botName: '小火',
+    date: '2026-08-01',
+    activity: {
+      sessions: [],
+      taskRuns: [],
+      orderCount: 0,
+      groupTasks: [],
+    },
+  });
+  assert.match(prompt.system, /capability_learnings/);
+  assert.match(prompt.user, /"capability_learnings"/);
+  assert.match(prompt.user, /capabilityType/);
+  assert.match(prompt.system, /reusable skills\/workflows/);
+});
+
+test('draft persistence: insertCapabilityDrafts + listCapabilityDrafts, no user_memories pollution', async () => {
+  const { db, cleanup } = await createSqliteStore();
+  try {
+    const coworkStore = createCoworkStore(db);
+
+    const beforeMemories = coworkStore.listUserMemories({ metabotId: 5, status: 'all', includeDeleted: true });
+    assert.equal(beforeMemories.length, 0, 'user_memories starts empty');
+
+    const inserted = coworkStore.insertCapabilityDrafts(5, '2026-08-01', [
+      { title: '演示视频工作流', description: '先素材后剪辑再确认。', capabilityType: 'workflow' },
+      { title: '   ', description: '空标题条目被跳过,不应该插入', capabilityType: 'skill' },
+      { title: '批处理工具模式', description: '按规则批量重命名。', capabilityType: 'tool_pattern' },
+      { title: '默认类型', description: '不传类型默认 skill。' },
+    ]);
+    assert.equal(inserted, 3, 'only valid entries are inserted');
+
+    const drafts = coworkStore.listCapabilityDrafts(5);
+    assert.equal(drafts.length, 3);
+    const byTitle = new Map(drafts.map((draft) => [draft.title, draft]));
+    const workflow = byTitle.get('演示视频工作流');
+    assert.equal(workflow.metabotId, 5);
+    assert.equal(workflow.dreamDate, '2026-08-01');
+    assert.equal(workflow.capabilityType, 'workflow');
+    assert.equal(workflow.status, 'draft');
+    assert.equal(typeof workflow.createdAt, 'number');
+    assert.equal(byTitle.get('批处理工具模式').capabilityType, 'tool_pattern');
+    assert.equal(byTitle.get('默认类型').capabilityType, 'skill');
+
+    // R4.3: the memory tables stay untouched by draft writes.
+    const afterMemories = coworkStore.listUserMemories({ metabotId: 5, status: 'all', includeDeleted: true });
+    assert.equal(afterMemories.length, 0, 'capability drafts must not create user_memories rows');
+
+    // listCapabilityDrafts() without a bot id returns everything.
+    const allDrafts = coworkStore.listCapabilityDrafts();
+    assert.equal(allDrafts.length, 3);
+
+    // Another bot's drafts are isolated.
+    assert.equal(coworkStore.listCapabilityDrafts(99).length, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('end-to-end: runNow persists capability_learnings as drafts (R4.2)', async () => {
+  const { db, cleanup } = await createSqliteStore();
+  try {
+    const coworkStore = createCoworkStore(db);
+    const { DreamStore } = loadCompiledModule('dreamStore.js');
+    const dreamStore = new DreamStore(db, () => {});
+    const DAY = '2026-07-30';
+    const DAY_START = new Date(2026, 6, 30).getTime();
+
+    const session = coworkStore.createSession('视频交付', '/tmp/a', '', 'local', [], 5);
+    db.run(
+      'INSERT INTO cowork_messages (id, session_id, type, content, metadata, created_at, sequence) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      ['m1', session.id, 'user', '视频做好了吗', '{}', DAY_START + 1000, 1],
+    );
+    db.run(
+      'INSERT INTO cowork_messages (id, session_id, type, content, metadata, created_at, sequence) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      ['m2', session.id, 'assistant', '做好了,你看下', '{}', DAY_START + 2000, 2],
+    );
+
+    const service = new DreamService({
+      coworkStore,
+      metabotStore: {
+        listMetabots: () => [
+          { id: 5, name: '小火', role: '视频创作者', soul: '认真严谨', llm_id: 'bot-own-llm', enabled: true },
+        ],
+      },
+      dreamStore,
+      performChat: async () => makePayload([
+        { title: '演示视频交付流程', description: '先确认需求,再制作,最后请用户验收。', capabilityType: 'workflow' },
+      ]),
+      llmTimeoutMs: 5000,
+      now: () => new Date(2026, 7, 1, 3, 0),
+    });
+
+    await service.runNow(5, DAY);
+
+    const drafts = coworkStore.listCapabilityDrafts(5);
+    assert.equal(drafts.length, 1);
+    assert.equal(drafts[0].title, '演示视频交付流程');
+    assert.equal(drafts[0].dreamDate, DAY);
+    assert.equal(drafts[0].capabilityType, 'workflow');
+    assert.equal(drafts[0].status, 'draft');
+    assert.equal(DREAM_VERSION, 8, 'dream version should be bumped for the new output channel');
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/groupTaskKickMemberRpc.test.mjs
+++ b/tests/groupTaskKickMemberRpc.test.mjs
@@ -115,6 +115,16 @@ async function startRpcServerForTest() {
         return () => {};
       },
     }),
+    // Phase 4: memory routes are not exercised here; a stub satisfies the
+    // new MemoryBackend getter argument.
+    () => ({
+      listUserMemories() {
+        return [];
+      },
+      createUserMemory() {
+        throw new Error('memory routes are not exercised in this test');
+      },
+    }),
   );
 
   await new Promise((resolve, reject) => {

--- a/tests/memoryGatewayRoutes.test.mjs
+++ b/tests/memoryGatewayRoutes.test.mjs
@@ -1,0 +1,382 @@
+/**
+ * Phase 4 (SDD R4.1) memory gateway route tests.
+ *
+ * Two levels:
+ *   1. pure route-logic tests — `handleMemoryListRoute` /
+ *      `handleMemoryCreateRoute` (memoryGatewayRoutes.ts) driven by a real
+ *      CoworkStore over an in-memory sql.js database: create + list round-trip
+ *      and every validation error path,
+ *   2. one integration test — boots the REAL metaidRpcServer (mocked electron
+ *      + listenWithRetry, same pattern as metaidRpcWalletRoutes.test.mjs) and
+ *      exercises POST /api/idbots/memory/create and /api/idbots/memory/list
+ *      over real HTTP, proving the routes are wired into the gateway chain.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+import { createCoworkStore, createSqliteStore, getRow } from './memoryTestUtils.mjs';
+
+const require = createRequire(import.meta.url);
+
+function resolveCompiledModulePath(relative) {
+  const candidates = [`../dist-electron/main/${relative}`, `../dist-electron/${relative}`];
+  for (const candidate of candidates) {
+    try {
+      return require.resolve(candidate);
+    } catch {
+      // Try next compile output layout.
+    }
+  }
+  return require.resolve(candidates[0]);
+}
+
+const {
+  handleMemoryCreateRoute,
+  handleMemoryListRoute,
+} = require(resolveCompiledModulePath('services/memoryGatewayRoutes.js'));
+
+const createBody = (overrides = {}) => JSON.stringify({
+  metabot_id: 1,
+  text: 'The client prefers concise replies',
+  ...overrides,
+});
+
+async function makeMemoryBackend() {
+  const { db, cleanup } = await createSqliteStore();
+  const coworkStore = createCoworkStore(db);
+  return { db, coworkStore, cleanup };
+}
+
+test('create + list round-trip persists a camelCase memory entry', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const created = handleMemoryCreateRoute(
+      () => coworkStore,
+      createBody({
+        scope: { kind: 'contact', key: 'metaweb_private:peer:peer-123' },
+        usage_class: 'preference',
+        is_explicit: true,
+      }),
+    );
+    assert.equal(created.status, 200);
+    assert.equal(created.body.success, true);
+    const memory = created.body.memory;
+    assert.equal(typeof memory.id, 'string');
+    assert.equal(memory.text, 'The client prefers concise replies');
+    assert.equal(memory.scopeKind, 'contact');
+    assert.equal(memory.scopeKey, 'metaweb_private:peer:peer-123');
+    assert.equal(memory.usageClass, 'preference');
+    assert.equal(memory.origin, 'conversation');
+    assert.equal(memory.isExplicit, true);
+    assert.equal(memory.status, 'created');
+
+    const listed = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      scope: { kind: 'contact', key: 'metaweb_private:peer:peer-123' },
+    }));
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.success, true);
+    assert.ok(Array.isArray(listed.body.memories));
+    assert.equal(listed.body.memories.length, 1);
+    assert.equal(listed.body.memories[0].id, memory.id);
+  } finally {
+    cleanup();
+  }
+});
+
+test('owner scope defaults to owner:self when scope.kind is owner without a key', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const created = handleMemoryCreateRoute(
+      () => coworkStore,
+      createBody({ scope: { kind: 'owner' } }),
+    );
+    assert.equal(created.status, 200);
+    assert.equal(created.body.memory.scopeKind, 'owner');
+    assert.equal(created.body.memory.scopeKey, 'owner:self');
+  } finally {
+    cleanup();
+  }
+});
+
+test('no scope falls back to the owner scope', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const created = handleMemoryCreateRoute(() => coworkStore, createBody());
+    assert.equal(created.status, 200);
+    assert.equal(created.body.memory.scopeKind, 'owner');
+    assert.equal(created.body.memory.scopeKey, 'owner:self');
+  } finally {
+    cleanup();
+  }
+});
+
+test('list filters by scope, status, usage_class and query', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    handleMemoryCreateRoute(() => coworkStore, createBody({
+      text: 'owner memory one',
+      scope: { kind: 'owner' },
+      usage_class: 'profile_fact',
+    }));
+    handleMemoryCreateRoute(() => coworkStore, createBody({
+      text: 'owner memory two',
+      scope: { kind: 'owner' },
+      usage_class: 'preference',
+    }));
+    handleMemoryCreateRoute(() => coworkStore, createBody({
+      text: 'contact memory',
+      scope: { kind: 'contact', key: 'metaweb_private:peer:peer-9' },
+    }));
+
+    // The unscoped list defaults to the owner scope (backend contract), so the
+    // contact memory is only visible through an explicit contact scope.
+    const all = handleMemoryListRoute(() => coworkStore, JSON.stringify({ metabot_id: 1 }));
+    assert.equal(all.body.memories.length, 2);
+
+    const contactScope = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      scope: { kind: 'contact', key: 'metaweb_private:peer:peer-9' },
+    }));
+    assert.deepEqual(contactScope.body.memories.map((m) => m.text), ['contact memory']);
+
+    const ownerOnly = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      scope: { kind: 'owner' },
+    }));
+    assert.equal(ownerOnly.body.memories.length, 2);
+
+    const preferenceOnly = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      usage_class: 'preference',
+    }));
+    assert.deepEqual(preferenceOnly.body.memories.map((m) => m.text), ['owner memory two']);
+
+    const queryHit = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      query: 'memory two',
+    }));
+    assert.deepEqual(queryHit.body.memories.map((m) => m.text), ['owner memory two']);
+
+    const statusCreated = handleMemoryListRoute(() => coworkStore, JSON.stringify({
+      metabot_id: 1,
+      status: 'created',
+    }));
+    assert.equal(statusCreated.body.memories.length, 2, 'unscoped status filter stays inside the owner scope');
+  } finally {
+    cleanup();
+  }
+});
+
+test('create with a source provenance records a source row', async () => {
+  const { db, coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const created = handleMemoryCreateRoute(() => coworkStore, createBody({
+      origin: 'dream',
+      source: { session_id: 'sess-1', role: 'assistant', source_type: 'dream', dream_date: '2026-08-01' },
+    }));
+    assert.equal(created.status, 200);
+    assert.equal(created.body.memory.origin, 'dream');
+    const sourceRow = getRow(
+      db,
+      'SELECT session_id, role, source_type, dream_date FROM user_memory_sources WHERE memory_id = ?',
+      [created.body.memory.id],
+    );
+    assert.equal(sourceRow.session_id, 'sess-1');
+    assert.equal(sourceRow.role, 'assistant');
+    assert.equal(sourceRow.source_type, 'dream');
+    assert.equal(sourceRow.dream_date, '2026-08-01');
+  } finally {
+    cleanup();
+  }
+});
+
+test('validation: invalid JSON body is rejected with 400', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const result = handleMemoryCreateRoute(() => coworkStore, '{not json');
+    assert.equal(result.status, 400);
+    assert.equal(result.body.success, false);
+    assert.match(result.body.error, /Invalid JSON/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('validation: missing metabot_id is rejected with 400', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    for (const body of ['{}', JSON.stringify({ text: 'no bot' }), JSON.stringify({ metabot_id: -1 })]) {
+      const result = handleMemoryCreateRoute(() => coworkStore, body);
+      assert.equal(result.status, 400, body);
+      assert.match(result.body.error, /metabot_id/);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('validation: empty text is rejected with 400', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    for (const bad of [undefined, '', '   ']) {
+      const result = handleMemoryCreateRoute(
+        () => coworkStore,
+        createBody(bad === undefined ? { text: undefined } : { text: bad }),
+      );
+      assert.equal(result.status, 400, JSON.stringify(bad));
+      assert.equal(result.body.error, 'text is required');
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('validation: invalid status / usage_class / scope kind / contact-key are typed 400s', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  try {
+    const badStatus = handleMemoryListRoute(() => coworkStore, JSON.stringify({ metabot_id: 1, status: 'bogus' }));
+    assert.equal(badStatus.status, 400);
+    assert.match(badStatus.body.error, /status/);
+
+    const badUsage = handleMemoryListRoute(() => coworkStore, JSON.stringify({ metabot_id: 1, usage_class: 'nope' }));
+    assert.equal(badUsage.status, 400);
+    assert.match(badUsage.body.error, /usage_class/);
+
+    const badScopeKind = handleMemoryCreateRoute(() => coworkStore, createBody({ scope: { kind: 'planet' } }));
+    assert.equal(badScopeKind.status, 400);
+    assert.match(badScopeKind.body.error, /scope\.kind/);
+
+    const contactWithoutKey = handleMemoryCreateRoute(() => coworkStore, createBody({ scope: { kind: 'contact' } }));
+    assert.equal(contactWithoutKey.status, 400);
+    assert.match(contactWithoutKey.body.error, /scope\.key/);
+
+    const keyWithoutKind = handleMemoryCreateRoute(() => coworkStore, createBody({ scope: { key: 'x' } }));
+    assert.equal(keyWithoutKind.status, 400);
+    assert.match(keyWithoutKind.body.error, /scope\.kind/);
+
+    const badOrigin = handleMemoryCreateRoute(() => coworkStore, createBody({ origin: 'hallucination' }));
+    assert.equal(badOrigin.status, 400);
+    assert.match(badOrigin.body.error, /origin/);
+
+    const badVisibility = handleMemoryCreateRoute(() => coworkStore, createBody({ visibility: 'public' }));
+    assert.equal(badVisibility.status, 400);
+    assert.match(badVisibility.body.error, /visibility/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('integration: real gateway routes memory create + list over HTTP', async () => {
+  const { coworkStore, cleanup } = await makeMemoryBackend();
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        app: {
+          getPath() {
+            return os.tmpdir();
+          },
+          getAppPath() {
+            return process.cwd();
+          },
+        },
+        BrowserWindow: {
+          getAllWindows() {
+            return [];
+          },
+        },
+      };
+    }
+    if (request === './httpListenWithRetry' || request.endsWith('/httpListenWithRetry')) {
+      return {
+        listenWithRetry(server, _port, host, options = {}) {
+          server.listen(0, host, () => {
+            if (typeof options.onListening === 'function') options.onListening();
+          });
+        },
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  let startMetaidRpcServer;
+  try {
+    const compiledRpcServerPath = resolveCompiledModulePath('services/metaidRpcServer.js');
+    delete require.cache[compiledRpcServerPath];
+    ({ startMetaidRpcServer } = require(compiledRpcServerPath));
+  } finally {
+    Module._load = originalLoad;
+  }
+
+  const server = startMetaidRpcServer(
+    () => ({}),
+    () => ({
+      getDatabase() {
+        return {};
+      },
+      getSaveFunction() {
+        return () => {};
+      },
+    }),
+    () => coworkStore,
+    undefined,
+  );
+
+  try {
+    await new Promise((resolve, reject) => {
+      if (server.listening) {
+        resolve();
+        return;
+      }
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : null;
+    assert.ok(port, 'server should bind a test port');
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const post = (pathname, body) =>
+      fetch(`${baseUrl}${pathname}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      });
+
+    // create over HTTP
+    const createResponse = await post('/api/idbots/memory/create', {
+      metabot_id: 1,
+      text: 'gateway round-trip memory',
+      scope: { kind: 'owner' },
+      usage_class: 'profile_fact',
+    });
+    assert.equal(createResponse.status, 200);
+    const created = await createResponse.json();
+    assert.equal(created.success, true);
+    assert.equal(created.memory.text, 'gateway round-trip memory');
+    assert.equal(created.memory.scopeKey, 'owner:self');
+
+    // list over HTTP sees it
+    const listResponse = await post('/api/idbots/memory/list', { metabot_id: 1 });
+    assert.equal(listResponse.status, 200);
+    const listed = await listResponse.json();
+    assert.equal(listed.success, true);
+    assert.deepEqual(listed.memories.map((m) => m.text), ['gateway round-trip memory']);
+
+    // validation errors over HTTP
+    const badResponse = await post('/api/idbots/memory/create', { metabot_id: 1 });
+    assert.equal(badResponse.status, 400);
+    const bad = await badResponse.json();
+    assert.equal(bad.success, false);
+    assert.equal(bad.error, 'text is required');
+
+    const missingBot = await post('/api/idbots/memory/list', {});
+    assert.equal(missingBot.status, 400);
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve()));
+    cleanup();
+  }
+});

--- a/tests/metaidRpcWalletRoutes.test.mjs
+++ b/tests/metaidRpcWalletRoutes.test.mjs
@@ -151,6 +151,16 @@ async function startRpcServerForTestWithOverrides({
         return () => {};
       },
     }),
+    // Phase 4: memory routes are not exercised here; a stub satisfies the
+    // new MemoryBackend getter argument.
+    () => ({
+      listUserMemories() {
+        return [];
+      },
+      createUserMemory() {
+        throw new Error('memory routes are not exercised in this test');
+      },
+    }),
     onBotBrowserOpen || onBotBrowserTabCommand
       ? {
           openBotBrowserUri: onBotBrowserOpen || undefined,


### PR DESCRIPTION
## Summary

Two capability additions for the DSH × IDBots integration (BotOS Phase 4):

1. **Scoped memory gateway routes** — `POST /api/idbots/memory/list` and `POST /api/idbots/memory/create` on the local RPC gateway, backed by the existing `MemoryBackend` (scoped by `metabot_id` + `scope`), so external processes (e.g. a DSH harness) can read/write a MetaBot's long-term memory over HTTP. Pure route logic lives in a new Electron-free module (`memoryGatewayRoutes.ts`); `startMetaidRpcServer` gains a `getMemoryBackend` parameter wired to `getCoworkStore`.

2. **Dream `capability_learnings` channel** — the nightly dream consolidation now also asks the bot's LLM to distill reusable-skill/workflow/tool-pattern candidates (`DreamOutput.capabilityLearnings`, ≤5, `DREAM_VERSION` 7→8) and persists them into a new idempotent `capability_drafts` table (L3b procedural-memory drafts). Existing memory/skill tables are untouched.

## Verification

- `npm run compile:electron` — 0 errors.
- New tests: `tests/memoryGatewayRoutes.test.mjs` (10, incl. a real-HTTP integration boot) + `tests/dreamCapabilityLearnings.test.mjs` (7, incl. an end-to-end `runNow` with stubbed LLM) — **17/17 pass**.
- Affected pre-existing suites (wallet routes, group-task kick, dreamPrompt/dreamService/dreamMemoryWrites/dreamFragments/dreamKnowledge) — **67/67 pass** (84/84 total).
- `git diff --check` clean; schema changes are idempotent (`CREATE TABLE IF NOT EXISTS`), no user-data migration impact.

## Notes

- Draft idempotency per dream date is intentionally left for a later phase (a re-dreamed date inserts fresh drafts).
- The DSH-side consumer tools (`idbots_memory_list` / `idbots_memory_create`) live in the companion `dsh-idbots-bridge` plugin (external to this repo).
