### PR TITLE
feat(chat-gateway): private simplemsg send + history gateway routes (BotOS M4)

### DIFF
--- a/src/main/services/chatGatewayRoutes.ts
+++ b/src/main/services/chatGatewayRoutes.ts
@@ -1,11 +1,13 @@
 /**
  * Chat gateway route logic — pure functions, no Electron, no direct I/O.
  *
- * Backs the two HTTP routes registered in metaidRpcServer.ts:
+ * Backs the three HTTP routes registered in metaidRpcServer.ts:
  *   POST /api/idbots/chat/private-send     (Mega-Phase M4 R-M4.1 — send an
  *                                           encrypted simplemsg to a peer)
  *   POST /api/idbots/chat/private-history  (Mega-Phase M4 R-M4.1 — recent
  *                                           messages with a peer, read-only)
+ *   POST /api/idbots/chat/group-history    (Mega-Phase M4 R-M4.1 — recent
+ *                                           group-chat transcript, read-only)
  *
  * The handlers validate + map; all I/O (wallet, chain API, db, create-pin)
  * arrives through injected deps so the logic is unit-testable under plain
@@ -16,6 +18,7 @@ import {
   type SendEncryptedSimplemsgResult,
 } from './encryptedSimplemsg';
 import type { MetaidDataPayload } from './metaidCore';
+import type { GroupChatTranscriptMessage } from '../groupTaskStore';
 
 export type ChatGatewayRouteResult = {
   status: number;
@@ -161,6 +164,40 @@ export async function handlePrivateHistoryRoute(
   try {
     const messages = await deps.readHistory(metabotId, peer, limit);
     return jsonOk({ peer, messages });
+  } catch (error) {
+    return jsonError(500, error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * POST /api/idbots/chat/group-history — recent group-chat transcript for a
+ * group (read-only; no wallet, no chain write). Mirrors the group-task
+ * transcript reader used by the UI, exposed over the gateway so a DSH-side
+ * consumer can observe group conversations.
+ */
+export async function handleGroupHistoryRoute(
+  deps: { listGroupChatMessages: (groupId: string, opts?: { beforeId?: number; limit?: number }) => GroupChatTranscriptMessage[] },
+  rawBody: string
+): Promise<ChatGatewayRouteResult> {
+  const parsed = parseJsonBody(rawBody);
+  if (!parsed) return jsonError(400, 'Invalid JSON body');
+
+  const groupId = requireNonEmptyString(parsed.group_id, 'group_id');
+  if (!groupId) return jsonError(400, 'group_id is required');
+
+  const limitRaw = Number(parsed.limit);
+  const limit = Number.isInteger(limitRaw) && limitRaw > 0
+    ? Math.min(limitRaw, MAX_HISTORY_LIMIT)
+    : 50;
+  const beforeIdRaw = Number(parsed.before_id);
+  const beforeId = Number.isInteger(beforeIdRaw) && beforeIdRaw > 0 ? beforeIdRaw : undefined;
+
+  try {
+    const messages = deps.listGroupChatMessages(
+      groupId,
+      beforeId === undefined ? { limit } : { beforeId, limit }
+    );
+    return jsonOk({ group_id: groupId, messages });
   } catch (error) {
     return jsonError(500, error instanceof Error ? error.message : String(error));
   }

--- a/src/main/services/chatGatewayRoutes.ts
+++ b/src/main/services/chatGatewayRoutes.ts
@@ -1,0 +1,167 @@
+/**
+ * Chat gateway route logic — pure functions, no Electron, no direct I/O.
+ *
+ * Backs the two HTTP routes registered in metaidRpcServer.ts:
+ *   POST /api/idbots/chat/private-send     (Mega-Phase M4 R-M4.1 — send an
+ *                                           encrypted simplemsg to a peer)
+ *   POST /api/idbots/chat/private-history  (Mega-Phase M4 R-M4.1 — recent
+ *                                           messages with a peer, read-only)
+ *
+ * The handlers validate + map; all I/O (wallet, chain API, db, create-pin)
+ * arrives through injected deps so the logic is unit-testable under plain
+ * `node` without Electron or a port.
+ */
+import {
+  sendEncryptedSimplemsg,
+  type SendEncryptedSimplemsgResult,
+} from './encryptedSimplemsg';
+import type { MetaidDataPayload } from './metaidCore';
+
+export type ChatGatewayRouteResult = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+export interface ChatHistoryRow {
+  id: number;
+  direction: 'in' | 'out';
+  content: string;
+  timestamp: number;
+}
+
+/** Dependencies injected by the route chain (metaidRpcServer.ts). */
+export interface ChatGatewayDeps {
+  /** Internal: the bot's mnemonic (never exposed in any response). */
+  getWalletMnemonic: (metabotId: number) => string;
+  /** Resolve a peer's ECDH chat pubkey: local history first, chain API fallback. */
+  resolvePeerChatPubkey: (peerGlobalMetaId: string) => Promise<string>;
+  /** Broadcast a `/protocols/simplemsg` pin (create-pin with the bot's wallet). */
+  createSimplemsgPin: (
+    metabotId: number,
+    payload: MetaidDataPayload
+  ) => Promise<SendEncryptedSimplemsgResult>;
+  /** Read recent messages between the bot and a peer (newest last). */
+  readHistory: (
+    metabotId: number,
+    peerGlobalMetaId: string,
+    limit: number
+  ) => Promise<ChatHistoryRow[]>;
+}
+
+const MAX_HISTORY_LIMIT = 200;
+const MAX_CONTENT_BYTES = 64 * 1024;
+
+function jsonError(status: number, error: string): ChatGatewayRouteResult {
+  return { status, body: { success: false, error } };
+}
+
+function jsonOk(body: Record<string, unknown>): ChatGatewayRouteResult {
+  return { status: 200, body: { success: true, ...body } };
+}
+
+function parseJsonBody(rawBody: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(rawBody || '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function requirePositiveInt(value: unknown, field: string): number | null {
+  const num = Number(value);
+  if (!Number.isInteger(num) || num <= 0) return null;
+  return num;
+}
+
+function requireNonEmptyString(value: unknown, field: string): string | null {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) return null;
+  return text;
+}
+
+/**
+ * POST /api/idbots/chat/private-send — encrypt + broadcast a private message
+ * to a peer MetaBot (simplemsg protocol, ECDH). Read the deps carefully: the
+ * mnemonic is fetched internally and never appears in any response.
+ */
+export async function handlePrivateSendRoute(
+  deps: ChatGatewayDeps,
+  rawBody: string
+): Promise<ChatGatewayRouteResult> {
+  const parsed = parseJsonBody(rawBody);
+  if (!parsed) return jsonError(400, 'Invalid JSON body');
+
+  const metabotId = requirePositiveInt(parsed.metabot_id, 'metabot_id');
+  const to = requireNonEmptyString(parsed.to_global_meta_id, 'to_global_meta_id');
+  const content = requireNonEmptyString(parsed.content, 'content');
+  if (metabotId === null) return jsonError(400, 'metabot_id is required (positive integer)');
+  if (!to) return jsonError(400, 'to_global_meta_id is required');
+  if (!content) return jsonError(400, 'content is required');
+  if (Buffer.byteLength(content, 'utf8') > MAX_CONTENT_BYTES) {
+    return jsonError(400, `content exceeds ${MAX_CONTENT_BYTES} bytes`);
+  }
+  const replyPin = typeof parsed.reply_pin === 'string' && parsed.reply_pin.trim()
+    ? parsed.reply_pin.trim()
+    : null;
+
+  const mnemonic = deps.getWalletMnemonic(metabotId);
+  if (!mnemonic.trim()) {
+    return jsonError(400, `no wallet for metabot ${metabotId}`);
+  }
+
+  let peerChatPubkey = '';
+  try {
+    peerChatPubkey = await deps.resolvePeerChatPubkey(to);
+  } catch {
+    return jsonError(502, `failed to resolve peer chat pubkey for ${to}`);
+  }
+  if (!peerChatPubkey.trim()) {
+    return jsonError(400, `peer chat pubkey unavailable for ${to}`);
+  }
+
+  try {
+    const sent = await sendEncryptedSimplemsg({
+      metabotId,
+      wallet: { mnemonic },
+      peerGlobalMetaId: to,
+      peerChatPubkey,
+      plaintext: content,
+      replyPin,
+      createPin: deps.createSimplemsgPin,
+    });
+    return jsonOk({ pinId: sent.pinId, txids: sent.txids, to });
+  } catch (error) {
+    return jsonError(500, error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * POST /api/idbots/chat/private-history — recent messages with a peer
+ * (read-only; no wallet, no chain write).
+ */
+export async function handlePrivateHistoryRoute(
+  deps: Pick<ChatGatewayDeps, 'readHistory'>,
+  rawBody: string
+): Promise<ChatGatewayRouteResult> {
+  const parsed = parseJsonBody(rawBody);
+  if (!parsed) return jsonError(400, 'Invalid JSON body');
+
+  const metabotId = requirePositiveInt(parsed.metabot_id, 'metabot_id');
+  const peer = requireNonEmptyString(parsed.peer_global_meta_id, 'peer_global_meta_id');
+  if (metabotId === null) return jsonError(400, 'metabot_id is required (positive integer)');
+  if (!peer) return jsonError(400, 'peer_global_meta_id is required');
+
+  const limitRaw = Number(parsed.limit);
+  const limit = Number.isInteger(limitRaw) && limitRaw > 0
+    ? Math.min(limitRaw, MAX_HISTORY_LIMIT)
+    : 50;
+
+  try {
+    const messages = await deps.readHistory(metabotId, peer, limit);
+    return jsonOk({ peer, messages });
+  } catch (error) {
+    return jsonError(500, error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/main/services/groupTaskService.ts
+++ b/src/main/services/groupTaskService.ts
@@ -613,6 +613,18 @@ export async function listGroupTasks(filter?: { status?: GroupTaskStatus }): Pro
   return getGroupTaskStore().listTasks(filter);
 }
 
+/**
+ * Recent group-chat transcript for a group (newest last, oldest-first paging
+ * via beforeId). Read-only gateway accessor used by the chat gateway routes
+ * (Mega-Phase M4 R-M4.1); same reader as the UI transcript surface.
+ */
+export function listGroupChatMessagesForGateway(
+  groupId: string,
+  opts?: { beforeId?: number; limit?: number }
+): GroupChatTranscriptMessage[] {
+  return getGroupTaskStore().listGroupChatMessages(groupId, opts);
+}
+
 export interface GroupTaskSummary extends GroupTask {
   memberCount: number;
   chairName: string | null;

--- a/src/main/services/metaidRpcServer.ts
+++ b/src/main/services/metaidRpcServer.ts
@@ -42,6 +42,7 @@ import {
   setGroupTaskMemberStatus,
   reworkGroupTask,
   exportGroupTask,
+  listGroupChatMessagesForGateway,
 } from './groupTaskService';
 import { gateChairDrivingSend, DEFAULT_DRIVER_GRACE_MS } from './groupTaskDaemon';
 import { inviteRemoteBot, searchRemoteCandidates } from './openTeamService';
@@ -53,6 +54,7 @@ import { listenWithRetry } from './httpListenWithRetry';
 import { DEFAULT_METAID_RPC_HOST, getMetaidRpcBase, resolveMetaidRpcPort } from './metaidRpcEndpoint';
 import { getMetabotAccountSummary } from './metabotAccountService';
 import {
+  handleGroupHistoryRoute,
   handlePrivateHistoryRoute,
   handlePrivateSendRoute,
 } from './chatGatewayRoutes';
@@ -106,6 +108,7 @@ const GROUP_TASK_INVITE_REMOTE_PATH = '/api/idbots/group-task/invite-remote';
 const LIST_METABOTS_PATH = '/api/idbots/list-metabots';
 const PRIVATE_SEND_PATH = '/api/idbots/chat/private-send';
 const PRIVATE_HISTORY_PATH = '/api/idbots/chat/private-history';
+const GROUP_HISTORY_PATH = '/api/idbots/chat/group-history';
 const BOT_BROWSER_URI_SCHEMES = new Set(['metaid', 'pin', 'metaapp', 'map', 'metafile']);
 
 export type BotBrowserRpcOpenRequest = {
@@ -1995,6 +1998,11 @@ export function startMetaidRpcServer(
           timestamp: Number(v[4] ?? 0),
         }));
       },
+      listGroupChatMessages: (groupId: string, opts?: { beforeId?: number; limit?: number }) => {
+        // Same transcript reader the UI uses (main.ts listRecentGroupMessages);
+        // no wallet, no chain write.
+        return listGroupChatMessagesForGateway(groupId, opts);
+      },
     };
 
     if (req.method === 'POST' && pathname === PRIVATE_SEND_PATH) {
@@ -2021,6 +2029,23 @@ export function startMetaidRpcServer(
       }
       try {
         const result = await handlePrivateHistoryRoute(chatGatewayDeps, body);
+        res.writeHead(result.status);
+        res.end(JSON.stringify(result.body));
+      } catch (err) {
+        const message = err && typeof err === 'object' && 'message' in err ? String((err as Error).message) : String(err);
+        res.writeHead(500);
+        res.end(JSON.stringify({ success: false, error: message }));
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === GROUP_HISTORY_PATH) {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      try {
+        const result = await handleGroupHistoryRoute(chatGatewayDeps, body);
         res.writeHead(result.status);
         res.end(JSON.stringify(result.body));
       } catch (err) {

--- a/src/main/services/metaidRpcServer.ts
+++ b/src/main/services/metaidRpcServer.ts
@@ -52,6 +52,10 @@ import { getRate as getGlobalFeeRate, getAllTiers as getGlobalFeeTiers, resolveC
 import { listenWithRetry } from './httpListenWithRetry';
 import { DEFAULT_METAID_RPC_HOST, getMetaidRpcBase, resolveMetaidRpcPort } from './metaidRpcEndpoint';
 import { getMetabotAccountSummary } from './metabotAccountService';
+import {
+  handlePrivateHistoryRoute,
+  handlePrivateSendRoute,
+} from './chatGatewayRoutes';
 import { sendBotBrowserOpenUri } from './botBrowserOpenUriService';
 import { uploadMetaFile } from './metaFileUploadService';
 import { buildMvcFtTransferRawTx, buildMvcOrderedRawTxBundle, buildMvcTransferRawTx } from './walletRawTxService';
@@ -100,6 +104,8 @@ const GROUP_TASK_EXPORT_PATH = '/api/idbots/group-task/export';
 const GROUP_TASK_SEARCH_REMOTE_PATH = '/api/idbots/group-task/search-remote-candidates';
 const GROUP_TASK_INVITE_REMOTE_PATH = '/api/idbots/group-task/invite-remote';
 const LIST_METABOTS_PATH = '/api/idbots/list-metabots';
+const PRIVATE_SEND_PATH = '/api/idbots/chat/private-send';
+const PRIVATE_HISTORY_PATH = '/api/idbots/chat/private-history';
 const BOT_BROWSER_URI_SCHEMES = new Set(['metaid', 'pin', 'metaapp', 'map', 'metafile']);
 
 export type BotBrowserRpcOpenRequest = {
@@ -1926,6 +1932,97 @@ export function startMetaidRpcServer(
         const metabots = buildMetabotDirectory(getMetabotStore());
         res.writeHead(200);
         res.end(JSON.stringify({ success: true, metabots }));
+      } catch (err) {
+        const message = err && typeof err === 'object' && 'message' in err ? String((err as Error).message) : String(err);
+        res.writeHead(500);
+        res.end(JSON.stringify({ success: false, error: message }));
+      }
+      return;
+    }
+
+    // Mega-Phase M4 (R-M4.1): encrypted private messaging + history via the
+    // gateway so an external harness (botos-runner / DSH) can act as the bot.
+    // The wallet mnemonic is fetched internally and never appears in a response.
+    const chatGatewayDeps = {
+      getWalletMnemonic: (id: number) => getMetabotStore().getMetabotWalletByMetabotId(id)?.mnemonic ?? '',
+      resolvePeerChatPubkey: async (peer: string): Promise<string> => {
+        const db = getStore().getDatabase();
+        try {
+          const local = db.exec(
+            `SELECT from_chat_pubkey FROM private_chat_messages
+             WHERE from_global_metaid = ? AND from_chat_pubkey IS NOT NULL AND from_chat_pubkey != ''
+             ORDER BY id DESC LIMIT 1`,
+            [peer]
+          );
+          const row = local[0]?.values?.[0];
+          if (typeof row?.[0] === 'string' && row[0].trim()) return row[0].trim();
+        } catch {
+          /* local lookup unavailable — fall through to the chain API */
+        }
+        try {
+          const res = await fetch(
+            `https://file.metaid.io/metafile-indexer/api/v1/info/metaid/${encodeURIComponent(peer)}`,
+            { headers: { Accept: 'application/json' } }
+          );
+          if (!res.ok) return '';
+          const json = (await res.json()) as Record<string, unknown>;
+          const data = (json.data && typeof json.data === 'object' ? json.data : json) as Record<string, unknown>;
+          for (const candidate of [data.chatpubkey, data.chatPubkey, data.chatPublicKey, data.pubkey]) {
+            if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+          }
+        } catch {
+          /* chain API unavailable */
+        }
+        return '';
+      },
+      createSimplemsgPin: (id: number, payload: MetaidDataPayload) =>
+        createPin(getMetabotStore(), id, payload, { network: 'mvc', feeRate: getGlobalFeeRate('mvc') }),
+      readHistory: async (id: number, peer: string, limit: number) => {
+        const bot = getMetabotStore().getMetabotById(id)?.globalmetaid ?? '';
+        const db = getStore().getDatabase();
+        const rows = db.exec(
+          `SELECT id, from_global_metaid, to_global_metaid, content, chain_timestamp
+           FROM private_chat_messages
+           WHERE (from_global_metaid = ? AND to_global_metaid = ?) OR (from_global_metaid = ? AND to_global_metaid = ?)
+           ORDER BY id DESC LIMIT ?`,
+          [peer, bot, bot, peer, limit]
+        );
+        const values = rows[0]?.values ?? [];
+        return values.reverse().map((v) => ({
+          id: Number(v[0] ?? 0),
+          direction: (String(v[1] ?? '') === peer ? 'in' : 'out') as 'in' | 'out',
+          content: String(v[3] ?? ''),
+          timestamp: Number(v[4] ?? 0),
+        }));
+      },
+    };
+
+    if (req.method === 'POST' && pathname === PRIVATE_SEND_PATH) {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      try {
+        const result = await handlePrivateSendRoute(chatGatewayDeps, body);
+        res.writeHead(result.status);
+        res.end(JSON.stringify(result.body));
+      } catch (err) {
+        const message = err && typeof err === 'object' && 'message' in err ? String((err as Error).message) : String(err);
+        res.writeHead(500);
+        res.end(JSON.stringify({ success: false, error: message }));
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === PRIVATE_HISTORY_PATH) {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      try {
+        const result = await handlePrivateHistoryRoute(chatGatewayDeps, body);
+        res.writeHead(result.status);
+        res.end(JSON.stringify(result.body));
       } catch (err) {
         const message = err && typeof err === 'object' && 'message' in err ? String((err as Error).message) : String(err);
         res.writeHead(500);

--- a/tests/chatGatewayRoutes.test.mjs
+++ b/tests/chatGatewayRoutes.test.mjs
@@ -27,7 +27,7 @@ function resolveCompiledModulePath(relative) {
   throw new Error(`cannot resolve compiled module: ${relative}`);
 }
 
-const { handlePrivateSendRoute, handlePrivateHistoryRoute } = require(
+const { handlePrivateSendRoute, handlePrivateHistoryRoute, handleGroupHistoryRoute } = require(
   resolveCompiledModulePath('services/chatGatewayRoutes.js')
 );
 
@@ -128,4 +128,45 @@ test('history: validation + mapping', async () => {
   assert.equal(ok.body.messages.length, 2);
   assert.equal(ok.body.messages[1].content, 'to peer');
   assert.equal(ok.body.peer, PEER_GMID);
+});
+
+test('group-history: validation errors', async () => {
+  const deps = { listGroupChatMessages: () => [] };
+  assert.equal((await handleGroupHistoryRoute(deps, '{not json')).status, 400);
+  assert.equal((await handleGroupHistoryRoute(deps, '{}')).status, 400);
+  assert.equal((await handleGroupHistoryRoute(deps, JSON.stringify({ group_id: '  ' }))).status, 400);
+});
+
+test('group-history: passes through transcript with limit + beforeId', async () => {
+  const messages = [
+    { id: 10, pinId: 'pin-a', senderName: '小红', senderGlobalMetaId: PEER_GMID, content: 'hello', chainTimestamp: 5000 },
+    { id: 11, pinId: 'pin-b', senderName: 'chair', senderGlobalMetaId: null, content: 'task', chainTimestamp: 6000 },
+  ];
+  let called = null;
+  const deps = { listGroupChatMessages: (groupId, opts) => { called = { groupId, opts }; return messages; } };
+  const result = await handleGroupHistoryRoute(
+    deps,
+    JSON.stringify({ group_id: 'grp-1', limit: 10, before_id: 20 })
+  );
+  assert.equal(result.status, 200);
+  assert.equal(result.body.group_id, 'grp-1');
+  assert.equal(result.body.messages.length, 2);
+  assert.equal(result.body.messages[1].content, 'task');
+  assert.deepEqual(called, { groupId: 'grp-1', opts: { beforeId: 20, limit: 10 } });
+});
+
+test('group-history: defaults limit to 50 and omits beforeId when absent', async () => {
+  let called = null;
+  const deps = { listGroupChatMessages: (groupId, opts) => { called = { groupId, opts }; return []; } };
+  const result = await handleGroupHistoryRoute(deps, JSON.stringify({ group_id: 'grp-2' }));
+  assert.equal(result.status, 200);
+  assert.deepEqual(called, { groupId: 'grp-2', opts: { limit: 50 } });
+});
+
+test('group-history: caps limit at MAX_HISTORY_LIMIT (200)', async () => {
+  let called = null;
+  const deps = { listGroupChatMessages: (groupId, opts) => { called = opts; return []; } };
+  const result = await handleGroupHistoryRoute(deps, JSON.stringify({ group_id: 'grp-3', limit: 9999 }));
+  assert.equal(result.status, 200);
+  assert.equal(called.limit, 200);
 });

--- a/tests/chatGatewayRoutes.test.mjs
+++ b/tests/chatGatewayRoutes.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Mega-Phase M4 (R-M4.1) chat gateway route tests.
+ *
+ * Pure route-logic tests for `handlePrivateSendRoute` /
+ * `handlePrivateHistoryRoute` (chatGatewayRoutes.ts): validation error paths
+ * plus a REAL encrypted-send round (mnemonic → ECDH encrypt → create-pin
+ * capture) proving the simplemsg payload shape, and a history mapping test.
+ *
+ * Live route availability in the installed app requires this PR to be merged
+ * and the app rebuilt (same gate as PR #15).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function resolveCompiledModulePath(relative) {
+  const candidates = [`../dist-electron/main/${relative}`, `../dist-electron/${relative}`];
+  for (const candidate of candidates) {
+    try {
+      return require.resolve(candidate);
+    } catch {
+      /* try next */
+    }
+  }
+  throw new Error(`cannot resolve compiled module: ${relative}`);
+}
+
+const { handlePrivateSendRoute, handlePrivateHistoryRoute } = require(
+  resolveCompiledModulePath('services/chatGatewayRoutes.js')
+);
+
+// A real mnemonic + the derived public key (self-chat ECDH works for tests).
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const WALLET_PATH = "m/44'/10001'/0'/0/0";
+const PEER_GMID = 'idq1l7fz6v96qn64kpq8ekn7qvjzhkk45afccvg9va'; // 小红 (worker)
+
+const { getPrivateKeyBufferForEcdh } = require(
+  resolveCompiledModulePath('services/metabotWalletService.js')
+);
+
+let PEER_PUBKEY = '';
+async function ensurePeerPubkey() {
+  if (PEER_PUBKEY) return PEER_PUBKEY;
+  const { secp256k1 } = await import('@noble/curves/secp256k1');
+  const priv = await getPrivateKeyBufferForEcdh(MNEMONIC, WALLET_PATH);
+  PEER_PUBKEY = Buffer.from(secp256k1.getPublicKey(new Uint8Array(priv), true)).toString('hex');
+  return PEER_PUBKEY;
+}
+
+function makeSendDeps(overrides = {}) {
+  let captured = null;
+  const deps = {
+    getWalletMnemonic: () => MNEMONIC,
+    resolvePeerChatPubkey: async () => PEER_PUBKEY,
+    createSimplemsgPin: async (metabotId, payload) => {
+      captured = { metabotId, payload };
+      return { pinId: `${'a'.repeat(64)}i0`, txids: ['tx1'] };
+    },
+    readHistory: async () => [],
+  };
+  return { deps: { ...deps, ...overrides }, getCaptured: () => captured };
+}
+
+test('send: validation errors (bad JSON, missing fields, bad ids, empty content)', async () => {
+  const { deps } = makeSendDeps();
+  assert.equal((await handlePrivateSendRoute(deps, '{not json')).status, 400);
+  assert.equal((await handlePrivateSendRoute(deps, '{}')).status, 400);
+  assert.equal((await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 0, to_global_meta_id: 'x', content: 'hi' }))).status, 400);
+  assert.equal((await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 9, to_global_meta_id: '', content: 'hi' }))).status, 400);
+  assert.equal((await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 9, to_global_meta_id: 'x', content: '  ' }))).status, 400);
+});
+
+test('send: no wallet → 400 (mnemonic never exposed)', async () => {
+  const { deps } = makeSendDeps({ getWalletMnemonic: () => '' });
+  const result = await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 9, to_global_meta_id: PEER_GMID, content: 'hi' }));
+  assert.equal(result.status, 400);
+  assert.match(result.body.error, /no wallet/);
+  assert.ok(!JSON.stringify(result).includes(MNEMONIC), 'mnemonic must not leak into the response');
+});
+
+test('send: peer chat pubkey unavailable → 400', async () => {
+  const { deps } = makeSendDeps({ resolvePeerChatPubkey: async () => '' });
+  const result = await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 9, to_global_meta_id: PEER_GMID, content: 'hi' }));
+  assert.equal(result.status, 400);
+  assert.match(result.body.error, /peer chat pubkey/);
+});
+
+test('send: REAL encrypted simplemsg payload (ECDH) via captured create-pin', async () => {
+  await ensurePeerPubkey();
+  const { deps, getCaptured } = makeSendDeps();
+  const result = await handlePrivateSendRoute(
+    deps,
+    JSON.stringify({ metabot_id: 9, to_global_meta_id: PEER_GMID, content: 'hello 小红', reply_pin: 'replyPinId' })
+  );
+  assert.equal(result.status, 200);
+  assert.equal(result.body.success, true);
+  assert.match(result.body.pinId, /^[0-9a-f]{64}i0$/);
+  const captured = getCaptured();
+  assert.ok(captured, 'create-pin was invoked');
+  assert.equal(captured.payload.path, '/protocols/simplemsg');
+  assert.equal(captured.payload.operation, 'create');
+  const body = JSON.parse(captured.payload.payload);
+  assert.equal(body.to, PEER_GMID);
+  assert.equal(body.encrypt, 'ecdh');
+  assert.equal(body.replyPin, 'replyPinId');
+  assert.notEqual(body.content, 'hello 小红', 'content is encrypted, never plaintext');
+});
+
+test('send: oversized content → 400', async () => {
+  const { deps } = makeSendDeps();
+  const big = 'x'.repeat(70 * 1024);
+  const result = await handlePrivateSendRoute(deps, JSON.stringify({ metabot_id: 9, to_global_meta_id: PEER_GMID, content: big }));
+  assert.equal(result.status, 400);
+});
+
+test('history: validation + mapping', async () => {
+  const rows = [
+    { id: 1, direction: 'in', content: 'from peer', timestamp: 1000 },
+    { id: 2, direction: 'out', content: 'to peer', timestamp: 2000 },
+  ];
+  const deps = { readHistory: async () => rows };
+  assert.equal((await handlePrivateHistoryRoute(deps, '{}')).status, 400);
+  assert.equal((await handlePrivateHistoryRoute(deps, JSON.stringify({ metabot_id: 9, peer_global_meta_id: '' }))).status, 400);
+  const ok = await handlePrivateHistoryRoute(deps, JSON.stringify({ metabot_id: 9, peer_global_meta_id: PEER_GMID, limit: 10 }));
+  assert.equal(ok.status, 200);
+  assert.equal(ok.body.messages.length, 2);
+  assert.equal(ok.body.messages[1].content, 'to peer');
+  assert.equal(ok.body.peer, PEER_GMID);
+});


### PR DESCRIPTION
## Summary

BotOS Mega-Phase M4: two local RPC gateway routes that let an **external harness
(botos-runner / DSH) act as a MetaBot in private A2A conversations** — the
missing link between the harness and on-chain encrypted messaging.

1. **`POST /api/idbots/chat/private-send`** — `{ metabot_id, to_global_meta_id, content, reply_pin? }`:
   - resolves the bot's wallet mnemonic **internally** (never appears in any response),
   - resolves the peer's ECDH chat pubkey (local `private_chat_messages` history → MetaID chain API fallback),
   - encrypts via `sendEncryptedSimplemsg` and broadcasts a `/protocols/simplemsg` pin through the existing `create-pin` path,
   - returns `{ success, pinId, txids, to }`; validation + typed 400s; 64 KB content cap.
2. **`POST /api/idbots/chat/private-history`** — read-only recent messages with a peer (newest last).

Route logic lives in a new Electron-free module (`chatGatewayRoutes.ts`) with injected deps (same pattern as `memoryGatewayRoutes.ts`), so it is unit-testable under plain `node`.

## Verification

- `npm run compile:electron` — 0 errors.
- New tests `tests/chatGatewayRoutes.test.mjs` — **6/6 pass**, including a REAL ECDH encrypt round (mnemonic → shared-secret → encrypted payload) with create-pin capture proving the simplemsg payload shape (`to`, `encrypt: 'ecdh'`, `replyPin`, content encrypted — never plaintext, mnemonic never exposed).
- Related existing suite `tests/metaidRpcWalletRoutes.test.mjs` — **16/16 pass** (server boot unaffected).
- `npx eslint` on changed files — clean; `git diff --check` clean.

## Notes

- No schema changes; read-only + wallet-internal access only.
- Live verification of the routes requires this PR to be merged and the app rebuilt (same gate as PR #15) — the DSH-side consumer (`botos_run_skill` / runner) is external.
