### PR TITLE
fix(group-tasks): deliverable ledger — local files upload on-chain as metafiles, reject/rework status backfill

### DIFF
--- a/src/main/groupTaskStore.ts
+++ b/src/main/groupTaskStore.ts
@@ -1897,6 +1897,27 @@ export class GroupTaskStore {
   }
 
   /**
+   * Ledger fix (#14→#16): bulk acceptance backfill for a task's deliverables.
+   * Only rows currently in `fromStatus` move — a corrected/re-delivered row
+   * keeps its verdict. The chair's reject (rework) marks pending rows
+   * 'rejected' so the verdict is traceable; acceptance later moves the
+   * remaining pending rows 'accepted'. Returns the number of rows updated.
+   */
+  updateDeliverablesStatusByTask(
+    taskId: number,
+    fromStatus: GroupTaskDeliverableStatus,
+    toStatus: GroupTaskDeliverableStatus,
+  ): number {
+    this.db.run(
+      'UPDATE group_task_deliverables SET status = ? WHERE task_id = ? AND status = ?',
+      [toStatus, taskId, fromStatus],
+    );
+    const changes = this.db.getRowsModified?.() ?? 0;
+    this.saveDb();
+    return changes;
+  }
+
+  /**
    * Issue #8: the ledger's on-chain confirmation state, driven by the daemon's
    * multi-source verification (verifyPinSources). 'confirmed' means the
    * deliverable's pin is verifiably present on-chain; it is ORTHOGONAL to

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3604,6 +3604,13 @@ const startSqliteDaemons = (): void => {
       };
     })(),
     sendOwnerPrivateReport: sendGroupTaskOwnerPrivateReport,
+    // Ledger fix (#14→#16): local file deliverables are uploaded on-chain as
+    // metafiles paid by the AUTHOR bot's wallet — same metaFileUploadService
+    // seam the OpenTeam guest daemon uses.
+    uploadDeliverableFile: async ({ metabotId, filePath, contentType }) => {
+      const { uploadMetaFile } = await import('./services/metaFileUploadService');
+      return uploadMetaFile(getMetabotStore(), { metabotId, filePath, contentType, network: 'mvc' });
+    },
     // OpenTeam M2: presence probe for remote-teammate unreachable detection
     // (idchat online-status API, shared lazy singleton).
     fetchRemotePresence: async (globalMetaIds) => {

--- a/src/main/services/groupTaskDaemon.ts
+++ b/src/main/services/groupTaskDaemon.ts
@@ -11,6 +11,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { SqliteDatabase as Database } from '../sqliteTypes';
 import type { MetabotStore } from '../metabotStore';
 import type { CoworkStore, CoworkSession } from '../coworkStore';
@@ -50,11 +52,17 @@ import {
 } from '../libs/experiencePromptBlocks';
 import {
   parseDeliverableLines,
+  parseDeliverableSegments,
+  extractLocalFilePaths,
   parseWorkingAck,
   hasStandbyMarker,
   isIntegrityDeclaration,
   type ParsedDeliverable,
 } from './groupTaskDeliverableParser';
+import { buildMetafileUri } from './serviceDeliveryArtifacts.js';
+import metaFileUploadShared from './metaFileUploadShared.js';
+
+const { inferContentTypeFromFilePath } = metaFileUploadShared;
 
 /** Alias kept for readability; the canonical value lives in groupTaskSession. */
 const CONVERSATION_CHANNEL = GROUP_TASK_CONVERSATION_CHANNEL;
@@ -883,6 +891,18 @@ export interface GroupTaskDaemonDeps {
   ackTimeoutMs?: number;
   /** P0-4: ms between retries of an unverified deliverable (default 10 min). */
   verificationRetryMs?: number;
+  /**
+   * Ledger fix (#14→#16): upload a LOCAL file deliverable on-chain as a
+   * metafile paid by the author bot's wallet, so a worker's local file path
+   * becomes verifiable chain evidence. Same seam the OpenTeam guest daemon
+   * uses (metaFileUploadService.uploadMetaFile). Unwired = text deliverables
+   * are recorded as-is (no on-chain upgrade).
+   */
+  uploadDeliverableFile?: (input: {
+    metabotId: number;
+    filePath: string;
+    contentType?: string;
+  }) => Promise<Record<string, unknown>>;
 }
 
 export interface GroupTaskDaemonLoop {
@@ -2270,16 +2290,25 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
     const candidatePinids = new Set(
       candidate.uri.match(/[0-9a-f]{64}i0/gi)?.map((token) => token.toLowerCase()) ?? [],
     );
+    // Ledger fix (#14→#16): a REJECTED row is also supersedeable — the same
+    // object re-delivered after the chair's reject is a new version of the
+    // same ledger row, re-opened to pending, not a duplicate row.
     const candidatesByAuthor = deps.getGroupTaskStore().listDeliverables(taskId)
       .filter((deliverable) =>
-        deliverable.status === 'pending'
+        (deliverable.status === 'pending' || deliverable.status === 'rejected')
         && Boolean(deliverable.authorGlobalmetaid)
         && deliverable.authorGlobalmetaid!.trim().toLowerCase() === author,
       )
       .slice()
       .reverse(); // newest rows first
     for (const deliverable of candidatesByAuthor) {
-      if (deliverable.uri === candidate.uri && deliverable.kind === candidate.kind) continue;
+      if (deliverable.uri === candidate.uri && deliverable.kind === candidate.kind) {
+        // A REJECTED row re-delivered with the SAME uri is a re-submission of
+        // the same object — it re-opens to pending instead of duplicating
+        // (the caller flips the status). Identical pending rows stay deduped.
+        if (deliverable.status === 'rejected') return deliverable;
+        continue;
+      }
       const oldPinids = new Set(
         (deliverable.uri ?? '').match(/[0-9a-f]{64}i0/gi)?.map((token) => token.toLowerCase()) ?? [],
       );
@@ -2343,6 +2372,9 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
       const msgPinId = message.pinId;
       const tagLines = deliverableTagLines(content);
       const candidates = parseDeliverableLines(content);
+      // Index-aligned raw segment text per candidate (ledger fix: text
+      // candidates may carry a local file path worth uploading on-chain).
+      const candidateSegments = parseDeliverableSegments(content);
       const recordedDeliverables: ParsedDeliverable[] = [];
       const rejected = candidates.filter((candidate) => !candidate.valid);
       if (rejected.length > 0) {
@@ -2352,7 +2384,8 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
         );
       }
       const isCorrection = /更正|修正|以…?为准|以此为准|请以此为准/.test(content);
-      for (const candidate of candidates) {
+      for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex += 1) {
+        const candidate = candidates[candidateIndex];
         if (!candidate.valid) continue; // placeholder/truncated/example → never recorded
         if (!msgPinId) continue;
         // Round-4 correction-first aggregation: a later message declaring
@@ -2363,6 +2396,11 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
           const superseded = findSupersededDeliverable(task.id, message.senderGlobalMetaId, candidate);
           if (superseded) {
             store.updateDeliverableUri(superseded.id, candidate.uri, candidate.kind);
+            // Ledger fix (#14→#16): a corrected object is a NEW version — a
+            // previously rejected verdict no longer applies, re-open it.
+            if (superseded.status === 'rejected') {
+              store.updateDeliverableStatus(superseded.id, 'pending');
+            }
             // P0-4: corrected deliverable is re-verified on the next monitor pass.
             store.updateDeliverableVerification(superseded.id, '{}');
             verificationNotes.push(
@@ -2432,6 +2470,56 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
                 `[GroupTaskDaemon] Task ${task.id}: deliverable #${deliverable.id} verification failed: ` +
                 `${error instanceof Error ? error.message : String(error)}`,
               );
+            }
+          }
+        }
+        // Ledger fix (#14→#16): a text deliverable whose segment names a LOCAL
+        // file is upgraded to on-chain evidence — the host uploads the file as
+        // a metafile (paid by the author bot) and rewrites the row in place.
+        // Upload failure degrades to the plain text record + a visible note;
+        // it never drops the deliverable row.
+        if (candidate.kind === 'text' && deps.uploadDeliverableFile) {
+          const segment = candidateSegments[candidateIndex] ?? '';
+          const filePath = extractLocalFilePaths(segment)[0];
+          // Only files that actually exist are upload candidates — a path
+          // mentioned in prose must never trigger an on-chain upload.
+          if (filePath && fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            const authorBotId = members.find((member) =>
+              Boolean(member.globalmetaid)
+              && member.globalmetaid!.toLowerCase() === String(message.senderGlobalMetaId ?? '').toLowerCase(),
+            )?.metabotId ?? null;
+            try {
+              const contentType = inferContentTypeFromFilePath(filePath);
+              const upload = await deps.uploadDeliverableFile({
+                metabotId: authorBotId ?? 0,
+                filePath,
+                contentType,
+              });
+              const pinId = typeof upload?.pinId === 'string' ? upload.pinId.trim() : '';
+              if (pinId) {
+                const uri = buildMetafileUri(pinId, {
+                  fileName: path.basename(filePath),
+                  contentType,
+                });
+                store.updateDeliverableUri(deliverable.id, uri, 'metafile');
+                // Reuse the pinid verification path so the upgraded row gets
+                // the same on-chain confirmation semantics as a native one.
+                const report = await verifyPinSources(pinId);
+                store.updateDeliverableVerification(deliverable.id, JSON.stringify(report));
+                store.updateDeliverableConfirmation(
+                  deliverable.id,
+                  report.verified ? 'confirmed' : 'unconfirmed',
+                );
+                verificationNotes.push(`✓ 本地交付物已上链为 ${uri}`);
+              } else {
+                verificationNotes.push(`⚠ 本地交付物上传未返回 pinId：${filePath}`);
+              }
+            } catch (error) {
+              emitLog(
+                `[GroupTaskDaemon] Task ${task.id}: local deliverable upload failed for ${filePath}: ` +
+                `${error instanceof Error ? error.message : String(error)}`,
+              );
+              verificationNotes.push(`⚠ 本地交付物上传失败（${filePath}）`);
             }
           }
         }

--- a/src/main/services/groupTaskDeliverableParser.ts
+++ b/src/main/services/groupTaskDeliverableParser.ts
@@ -159,29 +159,105 @@ function parseSegment(segment: string): ParsedDeliverable {
 }
 
 /**
- * Parse a full group message: every [DELIVERABLE] tag line, one candidate per
- * tag occurrence, in document order. Invalid candidates are returned with
- * valid=false so callers can skip them without losing the valid siblings.
+ * Scan a full group message for every [DELIVERABLE] tag occurrence and return
+ * the trimmed segment text AFTER each tag, in document order. One entry per
+ * tag occurrence (a line with two tags yields two entries); empty segments
+ * are skipped. Index-aligned with parseDeliverableLines — candidate[i] is the
+ * parse of segment[i] — so callers can inspect the raw segment of any
+ * candidate (e.g. the daemon's local-file delivery enhancement).
  */
-export function parseDeliverableLines(content: string): ParsedDeliverable[] {
+function scanDeliverableSegments(content: string): string[] {
   const text = String(content ?? '');
   if (!DELIVERABLE_TAG_TEST.test(text)) return [];
-  const results: ParsedDeliverable[] = [];
+  const segments: string[] = [];
   for (const line of text.split('\n')) {
     if (!DELIVERABLE_TAG_TEST.test(line)) continue;
     const parts = line.split(DELIVERABLE_TAG_SPLIT);
     for (const part of parts.slice(1)) {
       const segment = part.trim();
       if (!segment) continue;
-      results.push(parseSegment(segment));
+      segments.push(segment);
     }
   }
-  return results;
+  return segments;
+}
+
+/**
+ * Parse a full group message: every [DELIVERABLE] tag line, one candidate per
+ * tag occurrence, in document order. Invalid candidates are returned with
+ * valid=false so callers can skip them without losing the valid siblings.
+ */
+export function parseDeliverableLines(content: string): ParsedDeliverable[] {
+  return scanDeliverableSegments(content).map(parseSegment);
+}
+
+/**
+ * Raw segment text behind each parsed candidate, index-aligned with
+ * parseDeliverableLines (same document order, same skipping rules). Empty
+ * when the message carries no [DELIVERABLE] tag.
+ */
+export function parseDeliverableSegments(content: string): string[] {
+  return scanDeliverableSegments(content);
 }
 
 /** Text deliverables (valid, uri null) only — helper for callers that skip them. */
 export function isTextDeliverable(candidate: ParsedDeliverable): boolean {
   return candidate.valid && candidate.kind === 'text' && candidate.uri === null;
+}
+
+// ---------------------------------------------------------------------------
+// Local-file delivery enhancement (ledger fix, #14→#16 heritage)
+// ---------------------------------------------------------------------------
+// A worker often delivers a LOCAL file path (e.g. `/Users/me/work/index.html`
+// or `~/notes/spec.md`) instead of an on-chain uri. The daemon upgrades such
+// text deliverables to metafile:// on-chain evidence by uploading the file —
+// this extractor isolates the path tokens so the daemon only has to verify
+// existence and upload. Pure string extraction: no fs, no resolution.
+
+// Full-width parens terminate a path token (a `（…` right after a path is
+// almost always a prose annotation, e.g. `spec.md（含参数速查表）`). The
+// lookbehind excludes anything that is NOT a standalone absolute path: the
+// second slash of `scheme://…` (`/` or `:` before), URL path segments
+// (`https://host/path` — `.` before), and relative tokens (`foo/bar` —
+// word char before).
+const LOCAL_PATH_TOKEN_RE = /(?<![:/.\w])(~\/|\/(?!\/))[^\s"'`<>[\]{}|*（）]+/g;
+/** Paths that are NOT local files: on-chain schemes and protocol routes. */
+const NON_LOCAL_PATH_PREFIXES = [
+  'metaapp:', 'metafile:', 'metaid:', 'http:', 'https:', 'pin:', 'map:',
+  'buzz:', 'nostr:', 'ftp:',
+  '/protocols/', '/api/', '/browser/', '/buzz/', '/metaapp/', '/metaid/',
+];
+/** File tokens without a directory separator are not paths. */
+const HAS_SEPARATOR_RE = /\//;
+
+/** True when the token is a plausible LOCAL file path (absolute or ~/). */
+function looksLikeLocalPath(token: string): boolean {
+  if (NON_LOCAL_PATH_PREFIXES.some((prefix) => token.startsWith(prefix))) return false;
+  if (!HAS_SEPARATOR_RE.test(token)) return false;
+  if (token.endsWith('/') || token.endsWith('\\')) return false;
+  // `foo/bar` relative tokens resolve nowhere without a base — only absolute
+  // or home-relative paths are actionable for the uploader.
+  return token.startsWith('/') || token.startsWith('~/');
+}
+
+/**
+ * Extract local file path candidates from a [DELIVERABLE] segment (absolute
+ * or `~/`-rooted only; scheme URIs, `/protocols/…` routes and API paths are
+ * excluded). Trailing punctuation is trimmed. Existence is NOT checked here —
+ * the caller (daemon) stats the files and uploads the first hit.
+ */
+export function extractLocalFilePaths(text: string): string[] {
+  const content = String(text ?? '');
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const match of content.matchAll(LOCAL_PATH_TOKEN_RE)) {
+    const token = stripTrailingPunct(match[0]);
+    if (!looksLikeLocalPath(token)) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/services/groupTaskService.ts
+++ b/src/main/services/groupTaskService.ts
@@ -1435,6 +1435,18 @@ export async function reworkGroupTask(
     actor,
     reason: opts.reason?.trim() || null,
   });
+  // Ledger fix (#14→#16): the chair's reject (rework) is a verdict on the
+  // CURRENT deliverables — pending rows become 'rejected' so the acceptance
+  // history stays traceable in the ledger; a corrected re-delivery re-opens
+  // the row to 'pending' (see the daemon correction path). Best-effort.
+  try {
+    store.updateDeliverablesStatusByTask(taskId, 'pending', 'rejected');
+  } catch (error) {
+    console.warn(
+      `[GroupTask] Deliverable reject backfill failed for task ${taskId}: ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   if (orchestrationBridgeGetter) {
     try {
       orchestrationBridgeGetter().syncStatus(taskId);

--- a/tests/groupTaskDaemonProtocol.test.mjs
+++ b/tests/groupTaskDaemonProtocol.test.mjs
@@ -154,6 +154,7 @@ const createHarness = async (overrides = {}) => {
     ...(overrides.driverGraceMs != null ? { driverGraceMs: overrides.driverGraceMs } : {}),
     ...(overrides.readPinForVerification != null ? { readPinForVerification: overrides.readPinForVerification } : {}),
     ...(overrides.readPinSecondaryForVerification != null ? { readPinSecondaryForVerification: overrides.readPinSecondaryForVerification } : {}),
+    ...(overrides.uploadDeliverableFile != null ? { uploadDeliverableFile: overrides.uploadDeliverableFile } : {}),
   };
 
   const loop = createGroupTaskDaemonLoop(loopDeps);
@@ -523,6 +524,200 @@ test('Issue #8: monitor re-verification drives unconfirmed -> confirmed once the
     const deliverable = h.groupTaskStore.listDeliverables(task.id)[0];
     assert.equal(deliverable.confirmation, 'confirmed', 'monitor pass flips the ledger');
     assert.equal(deliverable.status, 'pending', 'acceptance status unchanged');
+  } finally {
+    h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Ledger fix (#14→#16): local-file deliverables are uploaded on-chain as
+// metafiles; reject/rework backfills deliverable status; transcript reads
+// stay id-ordered (show/dump consistency).
+// ---------------------------------------------------------------------------
+
+test('ledger fix: [DELIVERABLE] naming a LOCAL file is uploaded as metafile (uri + confirmed)', async () => {
+  const tempDir = makeTempDir();
+  const localFile = path.join(tempDir, 'visual-spec.md');
+  fs.writeFileSync(localFile, '# Visual spec\n');
+  const uploadedPin = 'd'.repeat(64) + 'i0';
+  const uploads = [];
+  const h = await createHarness({
+    uploadDeliverableFile: async (input) => {
+      uploads.push(input);
+      return { pinId: uploadedPin };
+    },
+    readPinForVerification: async (pinId) => (pinId === uploadedPin ? 'found' : 'not_found'),
+  });
+  try {
+    const task = h.createTask([2]);
+    insertGroupMessage(h.db, {
+      pinId: 'local-file-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot',
+      content: `[DELIVERABLE] 视觉规范文档：\`${localFile}\`（含参数速查表）`,
+    });
+    await h.loop.runTick();
+
+    const deliverables = h.groupTaskStore.listDeliverables(task.id);
+    assert.equal(deliverables.length, 1, 'one deliverable row recorded');
+    assert.equal(deliverables[0].kind, 'metafile', 'text row upgraded to metafile');
+    assert.equal(deliverables[0].uri, `metafile://${uploadedPin}.md`, 'uri carries the uploaded pinid + extension');
+    assert.equal(deliverables[0].confirmation, 'confirmed', 'on-chain confirmation follows the uploaded pin');
+    assert.equal(uploads.length, 1, 'exactly one upload');
+    assert.equal(uploads[0].filePath, localFile);
+    assert.equal(uploads[0].metabotId, 2, 'upload paid by the author bot wallet');
+    const parsed = JSON.parse(deliverables[0].verification ?? '{}');
+    assert.equal(parsed.verified, true, 'on-chain verification report persisted');
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('ledger fix: upload failure degrades to the plain text record (row kept, no fake uri)', async () => {
+  const tempDir = makeTempDir();
+  const localFile = path.join(tempDir, 'report.md');
+  fs.writeFileSync(localFile, 'x');
+  const h = await createHarness({
+    uploadDeliverableFile: async () => { throw new Error('wallet insufficient'); },
+  });
+  try {
+    const task = h.createTask([2]);
+    insertGroupMessage(h.db, {
+      pinId: 'upload-fail-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot',
+      content: `[DELIVERABLE] 报告：\`${localFile}\``,
+    });
+    await h.loop.runTick();
+
+    const deliverables = h.groupTaskStore.listDeliverables(task.id);
+    assert.equal(deliverables.length, 1, 'row still recorded');
+    assert.equal(deliverables[0].kind, 'text', 'no fake metafile kind');
+    assert.equal(deliverables[0].uri, null, 'no fake uri');
+    assert.equal(deliverables[0].confirmation, 'unconfirmed');
+    assert.ok(
+      h.logs.some((line) => line.includes('local deliverable upload failed')),
+      'failure is logged',
+    );
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('ledger fix: missing/non-file paths never trigger an upload', async () => {
+  const h = await createHarness({
+    uploadDeliverableFile: async () => {
+      throw new Error('upload must not be called for a missing file');
+    },
+  });
+  try {
+    const task = h.createTask([2]);
+    insertGroupMessage(h.db, {
+      pinId: 'no-file-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot',
+      content: '[DELIVERABLE] 结论：路径 `/tmp/idbots-no-such-dir-xyz/ghost.md` 不存在，仅作引用',
+    });
+    await h.loop.runTick();
+
+    const deliverables = h.groupTaskStore.listDeliverables(task.id);
+    assert.equal(deliverables.length, 1, 'row recorded as plain text');
+    assert.equal(deliverables[0].kind, 'text');
+    assert.equal(deliverables[0].uri, null);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('ledger fix: a correction to a REJECTED deliverable re-opens it to pending (new version, same row)', async () => {
+  const pinA = 'e'.repeat(64) + 'i0';
+  const h = await createHarness({
+    readPinForVerification: async () => 'found',
+  });
+  try {
+    const task = h.createTask([2]);
+    // A deliverable row that was REJECTED by the chair's rework.
+    const row = h.groupTaskStore.addDeliverable({
+      taskId: task.id,
+      msgPinId: 'rejected-msg-i0',
+      authorGlobalmetaid: 'gmid-w2',
+      kind: 'metaapp',
+      uri: `metaapp://${pinA}`,
+    });
+    h.groupTaskStore.updateDeliverableStatus(row.id, 'rejected');
+    assert.equal(h.groupTaskStore.listDeliverables(task.id)[0].status, 'rejected');
+
+    // The worker re-delivers the SAME object with a correction tag.
+    insertGroupMessage(h.db, {
+      pinId: 'correction-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot',
+      content: `[DELIVERABLE] 更正：修正版已重新发布，以 metaapp://${pinA} 为准`,
+    });
+    await h.loop.runTick();
+
+    const deliverables = h.groupTaskStore.listDeliverables(task.id);
+    assert.equal(deliverables.length, 1, 'corrected in place, no duplicate row');
+    assert.equal(deliverables[0].status, 'pending', 'rejected verdict re-opened to pending');
+    assert.equal(deliverables[0].uri, `metaapp://${pinA}`);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('ledger fix: reject backfill marks pending deliverables rejected (store-level)', async () => {
+  const h = await createHarness();
+  try {
+    const task = h.createTask([2]);
+    h.groupTaskStore.addDeliverable({ taskId: task.id, msgPinId: 'm1-i0', authorGlobalmetaid: 'gmid-w2', kind: 'text' });
+    const pin = 'f'.repeat(64) + 'i0';
+    h.groupTaskStore.addDeliverable({ taskId: task.id, msgPinId: 'm2-i0', authorGlobalmetaid: 'gmid-w3', kind: 'metaapp', uri: `metaapp://${pin}` });
+    const changed = h.groupTaskStore.updateDeliverablesStatusByTask(task.id, 'pending', 'rejected');
+    assert.equal(changed, 2, 'both pending rows rejected');
+    const rows = h.groupTaskStore.listDeliverables(task.id);
+    assert.ok(rows.every((row) => row.status === 'rejected'), 'all pending rows rejected');
+    assert.equal(h.groupTaskStore.updateDeliverablesStatusByTask(task.id, 'pending', 'rejected'), 0, 'idempotent');
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('show/dump consistency: transcript reads stay id-ordered even when chain timestamps are out of order', async () => {
+  const h = await createHarness();
+  try {
+    const task = h.createTask([2]);
+    // Deliberately insert with chain timestamps OUT of id order (backfill lag
+    // scenario): id order must still drive the transcript, never timestamps.
+    insertGroupMessage(h.db, {
+      pinId: 'm-a-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot', content: 'first message', chainTimestamp: 300,
+    });
+    insertGroupMessage(h.db, {
+      pinId: 'm-b-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot', content: 'second message', chainTimestamp: 100,
+    });
+    insertGroupMessage(h.db, {
+      pinId: 'm-c-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot', content: 'third message', chainTimestamp: 200,
+    });
+    const transcript = h.groupTaskStore.listGroupChatMessages(GROUP_ID, { limit: 50 });
+    assert.deepEqual(transcript.map((m) => m.id), [1, 2, 3], 'UI/show transcript is id-ordered');
+    assert.deepEqual(transcript.map((m) => m.content), ['first message', 'second message', 'third message']);
+
+    // The daemon's worker-context dump rides the SAME id-ordered query path
+    // (queryRecentMessages: ORDER BY id DESC LIMIT then reverse), so a reply
+    // turn produces a dump whose message order matches the UI transcript.
+    insertGroupMessage(h.db, {
+      pinId: 'm-d-i0', senderMetaId: 'metaid-1', senderGlobalMetaId: 'gmid-twin',
+      senderName: 'Twin Bot', content: '@Coder Bot 请按上述顺序复核', chainTimestamp: 400,
+    });
+    await h.loop.runTick();
+    assert.ok(h.chatCalls.length > 0, 'a reply turn ran for the trigger');
+    const dumpUser = h.chatCalls[0].userMessage;
+    const firstPos = dumpUser.indexOf('first message');
+    const secondPos = dumpUser.indexOf('second message');
+    const thirdPos = dumpUser.indexOf('third message');
+    const triggerPos = dumpUser.indexOf('请按上述顺序复核');
+    assert.ok(firstPos !== -1 && secondPos !== -1 && thirdPos !== -1 && triggerPos !== -1,
+      'dump carries every message');
+    assert.ok(firstPos < secondPos && secondPos < thirdPos && thirdPos < triggerPos,
+      'dump order equals the id-ordered UI transcript');
   } finally {
     h.cleanup();
   }

--- a/tests/groupTaskDeliverableParser.test.mjs
+++ b/tests/groupTaskDeliverableParser.test.mjs
@@ -304,3 +304,45 @@ test('P0-8: isIntegrityDeclaration recognizes honest correction language', () =>
   assert.equal(isIntegrityDeclaration('如实说明：该 pinid 未发布成功'), true);
   assert.equal(isIntegrityDeclaration('普通消息没有任何关键词'), false);
 });
+
+// ---------------------------------------------------------------------------
+// Ledger fix (#14→#16): local-file path extraction + segment alignment
+// ---------------------------------------------------------------------------
+
+test('ledger fix: parseDeliverableSegments aligns 1:1 with parseDeliverableLines', () => {
+  const { parseDeliverableLines, parseDeliverableSegments } = require('../dist-electron/main/services/groupTaskDeliverableParser.js');
+  const content = [
+    '① 完成。',
+    `**[DELIVERABLE] metaapp: metaapp://${PIN_A}**`,
+    `**[DELIVERABLE] 视觉规范文档：\`/Users/tusm/work/spec.md\`（含参数表）**`,
+    `**[DELIVERABLE] 架构文档**`,
+    '',
+  ].join('\n');
+  const candidates = parseDeliverableLines(content);
+  const segments = parseDeliverableSegments(content);
+  assert.equal(candidates.length, 3);
+  assert.equal(segments.length, 3);
+  assert.match(segments[0], /metaapp:\/\/[0-9a-f]{64}i0/);
+  assert.match(segments[1], /spec\.md/);
+  assert.match(segments[2], /架构文档/);
+  // A message without the tag yields empty segments.
+  assert.deepEqual(parseDeliverableSegments('no tag here'), []);
+});
+
+test('ledger fix: extractLocalFilePaths returns absolute/~ paths, skips schemes and prose', () => {
+  const { extractLocalFilePaths } = require('../dist-electron/main/services/groupTaskDeliverableParser.js');
+  // Absolute path in backticks with a full-width-paren annotation.
+  assert.deepEqual(
+    extractLocalFilePaths('视觉规范文档：`/Users/tusm/work/电影化视觉规范-v1.md`（含 §7 参数速查表）'),
+    ['/Users/tusm/work/电影化视觉规范-v1.md'],
+  );
+  // Home-relative path.
+  assert.deepEqual(extractLocalFilePaths('数据源：~/projects/film-data.js'), ['~/projects/film-data.js']);
+  // On-chain schemes and protocol routes are never local files.
+  assert.deepEqual(extractLocalFilePaths(`metaapp://${PIN_A} 与 /protocols/simplebuzz 与 https://a.b/c`), []);
+  // A bare filename is not a path.
+  assert.deepEqual(extractLocalFilePaths('文件：index.html'), []);
+  // Multiple distinct paths, deduped, punctuation trimmed.
+  const multi = extractLocalFilePaths('`/a/b/f1.md` 与 `/a/b/f2.md`，以及 /a/b/f1.md');
+  assert.deepEqual(multi, ['/a/b/f1.md', '/a/b/f2.md']);
+});


### PR DESCRIPTION
## 缺陷(三次复现,群任务 #14→#15→#16)

真实台账实证(本机 IDBots 用户库 `group_task_deliverables` #14/#15/#16):

- #16 全部 11 行交付物 `kind=text, uri=NULL, status=pending, confirmation=unconfirmed`;#14/#15 已 done 的行回填为 accepted 但同样全是 `uri=NULL`
- 群聊原始消息取证:worker 交付大量**本地文件路径**与**纯文本结论**——485(eleven)`` `…/电影化视觉规范-v1.md` ``、505/531(chair)`` `…/film-data-s3.js` ``、532(loop)`` `…/架构复核-v1.md` ``、561(我)`` `…/xiyouji-movie/index.html` ``,parser 按设计归类为 text(uri=null)
- Chair 无法链上复核「无 uri、无来源 URL」→ 拒签退回;`status` 只回填 accepted(acceptGroupTask),**拒签(rejected)无任何写入路径**

## 修复

1. **daemon 采集**:text [DELIVERABLE] 段含**真实存在的本地文件**时,经 `uploadDeliverableFile`(作者 bot 钱包,与 OpenTeam guest 同一 metaFileUploadService seam)上传为 metafile,行就地升级为 `metafile://pinid` + kind=metafile + 链上 verification/confirmation;上传失败降级保持 text 并留可见说明,绝不丢行、绝不产生假 uri
2. **parser**:新增 `parseDeliverableSegments`(与 candidates 索引对齐的原文段)与 `extractLocalFilePaths`(绝对/`~/` 路径;排除 scheme://、URL 路径段、相对路径、协议路由)
3. **验收回填**:`reworkGroupTask`(Chair 拒签)把 pending 交付物批量标 `rejected`;daemon 更正路径把 rejected 行就地重开为 pending(同对象新版本,同 ledger 行,不重复造行);acceptGroupTask 原有 pending→accepted 保持不变
4. **store**:新增 `updateDeliverablesStatusByTask` 批量回填(幂等,getRowsModified 计数)

## 验证

- 新增 9 个测试(本地文件上链+confirmation、上传失败降级、缺失文件不触发上传、rejected 更正重开、拒签批量回填、show/dump 排序一致性、parser 段对齐/路径提取)
- 回归:304 个相关测试全绿(daemon/store/service/bridge/parser/acceptance/checkpoints/openTeam 等),0 失败
- 真实数据反向验证:`extractLocalFilePaths` 对 #15 真实消息(485/505/532)提取正确,纯文本(390)保持 text

## (b) 核查结论

`action:show`(RPC show / UI transcript)与 worker 会话 dump(`queryRecentMessages`)数据源同源(均读 `group_chat_messages`、按 id 升序);本机 893 条群消息 id 顺序与 chain_timestamp 完全一致(0 乱序)。新增排序一致性测试固化该不变量。若修复后 (b) 仍复现,按委派可证伪条件判定为与 (a) 不同源,需拆单——当前证据显示 (b) 所述现象在 main 上不复现。
