### PR TITLE
fix(group-task): long-turn workers no longer mis-flagged unreachable; verify status transitions are event-driven

### DIFF
--- a/src/main/libs/opcatInscribe.ts
+++ b/src/main/libs/opcatInscribe.ts
@@ -6,7 +6,6 @@
  * use @opcat-labs/scrypt-ts-opcat instead of standard bitcoinjs-lib.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyOpcat = any;
 
 const OPCAT_WALLET_API = 'https://wallet-api.opcatlabs.io';

--- a/src/main/services/groupTaskDaemon.ts
+++ b/src/main/services/groupTaskDaemon.ts
@@ -3822,9 +3822,11 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
   };
 
   /**
-   * R6 L2: once a working/assigned LOCAL worker's [WORKING] signal goes stale
-   * (older than the timeout window), inject a deterministic "re-assign" hint
-   * into the chair's next turn and mark the authoritative state timeout. This
+   * R6 L2 + R1 (long-turn): once a working/assigned LOCAL worker shows no
+   * working activity (no [WORKING] signal AND no speech — any worker speech is
+   * implicit working evidence, same rule as the implicit-ACK path) for longer
+   * than the timeout window, inject a deterministic "re-assign" hint into the
+   * chair's next turn and mark the authoritative state timeout. This
    * is the escalation ABOVE the existing L1 ACK/delivery reminders: those fire
    * once per assignment at 3 min; this fires once per (task, member) timeout
    * streak — the chair gets a concrete "re-assign to a standby member or mark
@@ -3851,6 +3853,16 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
       task.groupId,
       workers.map((member) => member.globalmetaid),
     );
+    // R1 (long-turn fix): the staleness basis is the LATER of the last explicit
+    // [WORKING] timestamp and the member's actual last chain speech. A long-turn
+    // worker (render / batch generation) who posted [WORKING] and keeps posting
+    // progress or [DELIVERABLE]s — without re-tagging [WORKING] — is demonstrably
+    // alive, so it must never be flagged stale/error. Only TOTAL silence past the
+    // window escalates. Chair members never ride this worker-rhythm path.
+    const speakMap = store.getMembersLastSpeakAt(
+      task.groupId,
+      workers.map((member) => member.globalmetaid),
+    );
     const standbyNames = members
       .filter((member) => member.role === 'worker' && member.status === 'standby')
       .map((member) => member.name ?? `bot-${member.metabotId}`);
@@ -3859,9 +3871,12 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
     const timedOut: string[] = [];
     for (const member of workers) {
       const gmid = (member.globalmetaid ?? '').trim().toLowerCase();
-      const lastWorkingSec = gmid ? workingMap.get(gmid) ?? null : null;
-      if (lastWorkingSec == null) continue;
-      const staleMs = now() - lastWorkingSec * 1000;
+      if (!gmid) continue;
+      const workingSec = workingMap.get(gmid) ?? 0;
+      const speakSec = speakMap.get(gmid) ?? 0;
+      const lastActiveSec = Math.max(workingSec, speakSec) || null;
+      if (lastActiveSec == null) continue;
+      const staleMs = now() - lastActiveSec * 1000;
       if (staleMs <= memberTimeoutAfterMinutes * 60_000) continue;
 
       const name = member.name ?? `bot-${member.metabotId}`;
@@ -3881,7 +3896,7 @@ export function createGroupTaskDaemonLoop(deps: GroupTaskDaemonDeps): GroupTaskD
         timedOut.push(name);
         sqlite.set(hintKey, '1');
         emitLog(
-          `[GroupTaskDaemon] Task ${task.id}: ${name} [WORKING] signal stale (${memberTimeoutAfterMinutes}+ min); ` +
+          `[GroupTaskDaemon] Task ${task.id}: ${name} no working activity (signal/speech) for ${memberTimeoutAfterMinutes}+ min; ` +
           'injecting chair re-assign hint',
         );
       }

--- a/src/renderer/components/settings/MemorySettings.tsx
+++ b/src/renderer/components/settings/MemorySettings.tsx
@@ -306,7 +306,6 @@ const MemorySettings: React.FC<{ onClose: () => void }> = ({ onClose }) => {
 
   const handleDeleteKnowledge = async (entry: CoworkKnowledgeEntry) => {
     if (metabotId == null) return;
-    // eslint-disable-next-line no-alert
     if (!window.confirm(i18nService.t('memoryKnowledgeDeleteHint'))) return;
     try {
       const ok = await coworkService.deleteKnowledge({ id: entry.id, metabotId });

--- a/tests/groupTaskDaemon.test.mjs
+++ b/tests/groupTaskDaemon.test.mjs
@@ -548,6 +548,45 @@ test('R6: stale [WORKING] local worker → timeout status + L3 owner brief (idem
   }
 });
 
+test('R1: a long-turn worker who spoke after [WORKING] is never flagged stale/unreachable', async () => {
+  const h = await createHarness({
+    workerCooldownMs: 0,
+    chairCooldownMs: 0,
+    // Fast windows so the test doesn't wait real minutes.
+    deps: { memberTimeoutAfterMinutes: 1, memberEscalateAfterMinutes: 1 },
+  });
+  try {
+    const task = h.createTask([2]);
+    // Worker 2 ACKed [WORKING] with a chain timestamp ~16.7 min in the past —
+    // the *[WORKING]-only* basis would already be stale at the default nowMs.
+    insertGroupMessage(h.db, {
+      pinId: 'working-old-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot', content: '[WORKING] 已接单，渲染中', chainTimestamp: 999_999_000,
+    });
+    // ...but it keeps posting progress 50s ago (no [WORKING] re-tag): that is
+    // implicit working evidence — the long-turn worker is alive and must not be
+    // escalated by monitorLocalWorkerTimeout.
+    insertGroupMessage(h.db, {
+      pinId: 'progress-i0', senderMetaId: 'metaid-2', senderGlobalMetaId: 'gmid-w2',
+      senderName: 'Coder Bot', content: '进度：第 12 帧渲染完成，继续', chainTimestamp: 999_999_950,
+    });
+    h.groupTaskStore.setMemberStatus(task.id, 2, 'working', 'gmid-w2');
+    // Advance the daemon cursor past both messages so the tick's timeout monitor
+    // runs against the persisted chain timestamps (isolated from the protocol
+    // marker handler re-marking the member).
+    const lastId = h.db.exec('SELECT MAX(id) AS id FROM group_chat_messages')[0].values[0][0];
+    h.groupTaskStore.updateLastProcessedMsgId(task.id, lastId);
+    await h.loop.runTick();
+
+    // R1: recent speech refreshes the working basis → NOT marked unreachable.
+    const member = h.groupTaskStore.listMembers(task.id).find((m) => m.metabotId === 2);
+    assert.equal(member.status, 'working', 'long-turn worker with recent speech stays working');
+    assert.equal(h.ownerReportCalls.length, 0, 'no L3 owner brief for an active worker');
+  } finally {
+    h.cleanup();
+  }
+});
+
 test('cursor advances on no-reply messages; a failing message holds the batch (fail-stop) until it recovers', async () => {
   // Cooldowns off: this test isolates the fail-stop/retry ordering semantics.
   const h = await createHarness({ workerCooldownMs: 0, chairCooldownMs: 0 });

--- a/tests/privateChatScopedMemory.test.mjs
+++ b/tests/privateChatScopedMemory.test.mjs
@@ -439,7 +439,7 @@ test('CoworkRunner keeps the full common outer prompt for standard cowork sessio
   // `<ownerMemories>\n- <text>` — assert that form is absent from the system prompt.
   assert.doesNotMatch(systemPrompt, /<ownerMemories>\n-/);
   assert.doesNotMatch(systemPrompt, /Local Time Context/);
-  assert.match(systemPrompt, /Do not use AskUserQuestion in this session/);
+  assert.match(systemPrompt, /Do not use the ask-user question tool in this session/);
 });
 
 test('cleanServiceResultText strips bot-to-bot wrapper and order metadata from mixed replies', async () => {


### PR DESCRIPTION
# PR 描述 v1.0 — group-task：长回合成员误标 unreachable 修复 + status 转换核验

> 起草人：小刚（S2，规格轨）｜2026-08-24
> 依据：《IDBots 状态机同步问题报告 v1》+ 小红 S3 回源核验审计 + 小明 S1/S4 定位与修复实况
> 定稿基准：chair（小峰）S2 定稿规格（[STATUS:EXECUTING]，2026-08-24）——冲突处**以审计第五节兜底**
> 目标仓库：https://github.com/metaid-developers/IDBots
> 基线：upstream/main `012557f6`（v0.5.4）｜分支：`fix/group-task-state-sync`（本地 worktree，5 files，+62/−10）

---

## 建议标题
`fix(group-task): long-turn workers no longer mis-flagged unreachable; verify status transitions are event-driven`

## 摘要（范围声明）

- **核心改动（R1）**：`monitorLocalWorkerTimeout` 的 stale 判定基准从「仅 `[WORKING]` 链时间戳」改为「`max(最后一次[WORKING]时间戳, 最后一次链上发言时间戳)`」。长回合成员（渲染 / 批量出图）开工回 `[WORKING]` 后不重标、但持续发言（进度 / deliverable）时，不再被误标 `stale`/`unreachable` 并触发 chair 重派提示；**完全静默**仍按原逻辑升级（R6 保留）。
- **核验结论（R2，零代码改动，按 chair 终裁口径）**：`status 转换实测为 tag 驱动、近即时（9-10s）；UI 层有 statusChanged push + 5s 轮询自愈；v0.5.4 两层均无复现缺陷，原观察基于更早构建，已缓解；若仍复现，按复现路径另开 issue 追踪`。`group_task_transitions.reason` 明确为 `[STATUS:REVIEW] tag` / `[STATUS:EXECUTING] tag`；cooldown 未阻塞本次转换。故本 PR **唯一代码改动是 R1，R2 零代码改动、仅文档化上述调查结论**。
- **附带（CI 通过所需，均属 base 既有问题、非本次改动引入）**：清理 2 处 unused `eslint-disable`；对齐 1 处过期断言文本。
- **范围外（建议后续 PR，不随本 PR）**：R3 验收摘要「未链上确认」的链上核验；R4 钱包余额不足的发送失败回写与 owner 告警。

---

## 一、现象（owner 视角，已按回源核验修正）

| # | 现象 | 核验后结论 |
|---|---|---|
| 1 | 任务状态灯与真实进展不对应（status 迟迟不翻） | ⚠️ 核验为 **tag 驱动近即时（9-10s）**，DB 无"迟迟不翻"；UI 层有 push+5s 轮询自愈；v0.5.4 两层均无复现缺陷（已缓解），若仍复现按复现路径另开 issue |
| 2 | 已交付成员被标 `error`/`unreachable` | ✅ 部分成立：task37 小红已交付仍被标 `unreachable`（18:53:35，实证）；「chair 被标 timeout」**无证据，已删除**（DB 中 chair=working，且 status 无 timeout 取值） |
| 3 | 验收摘要误报「交付物均未链上确认」 | ✅ 成立（R3）：8 条交付 pin 均在链上、本地 `confirmation` 却全为 `unconfirmed` |
| 4 | 偶发报错 | ⚠️ 部分成立：`Skill turn timed out` 多处实证；`group-history` 接口 429 可复现；`WORKER_NO_REPLY` 在 main.log **无字面量**，已删除 |

## 二、根因

- **R1（本 PR 修复，成立）**：`workStatus` 判定 = 显式 `[WORKING]` 信号 + 时间戳推断，长回合没有「工作结束」显式事件，仅靠「下次发言」隐式 ACK；超过 20 分钟阈值即判 `stale` → `unreachable` + 注入 chair 重派提示。**与 `monitorMemberUnreachable` / `monitorAcksAndReminders` 既有的「发言=engaged」原语不一致**——后两者早已把任何发言当作工作证据，唯独 `monitorLocalWorkerTimeout` 只看 `[WORKING]` 链。
- **R2（调查结论，不成立原描述）**：status 转换实测为 tag 驱动、近即时（9-10s）；UI 层有 `statusChanged` push + 5s 轮询自愈；**v0.5.4 两层均无复现缺陷**，原观察基于更早构建、已随事件驱动转换落地而缓解；若仍复现，按复现路径另开 issue 追踪（本 PR 不动 daemon 与 UI）。
- **R3（成立，本 PR 不修）**：acceptance summary 从本地快照生成，8 条交付 pin 在链上但 `confirmation` 未回写 → 误报「未链上确认」。
- **R4（部分成立，本 PR 不修）**：钱包余额不足 `Send failed` 实测仅 08-08 私聊（46×）与 08-24 task37 两处；原始报告的 08-16/21/22 归因错误（实为 task done/cancelled，非余额）。

## 三、改动点（文件 + 行号，基于基线 012557f6 实测）

**核心（R1）**
1. `src/main/services/groupTaskDaemon.ts:3837` `monitorLocalWorkerTimeout` — stale 基准改为 `max(lastWorkingAt, lastSpeakAt)`；复用既有 store 原语 `store.getMembersLastSpeakAt`（`src/main/groupTaskStore.ts:1965`，已被 `monitorMemberUnreachable`(:3789) 与 `monitorAcksAndReminders`(:4105) 使用）。修复块约 L3853–3882。chair 成员不进入该 worker 节奏判定路径。
2. `tests/groupTaskDaemon.test.mjs:551` 新增反向测试 `R1: a long-turn worker who spoke after [WORKING] is never flagged stale/unreachable`（长回合有发言→保持 `working`、无 owner 简报）。

**附带（CI 通过所需，base 既有问题）**
3. `src/main/libs/opcatInscribe.ts:8` — 删除 unused `eslint-disable-next-line @typescript-eslint/no-explicit-any`。
4. `src/renderer/components/settings/MemorySettings.tsx:308` — 删除 unused `eslint-disable-next-line no-alert`（`handleDeleteKnowledge` 内）。
5. `tests/privateChatScopedMemory.test.mjs:442` — 对齐 1 处过期断言文本（`Do not use the ask-user question tool...`）。

## 四、验证方案与结果

| 检查 | 结果 |
|---|---|
| `tests/groupTaskDaemon.test.mjs`（覆盖本改动套件） | ✅ 104/104（含原 R6 + 新增 R1） |
| `npm run lint` | ✅ 通过（清理 2 处 base 既有 unused eslint-disable 后） |
| `npm run build` | ✅ 通过 |
| `npm run test:memory` | ✅ 59/59（对齐 1 处 base 既有过期断言后） |
| `npm run test:wallet` / `test:subsidy` | ⚠️ **base 既有破损脚本（外部阻塞）**：`package.json` 指向的 `metabotWalletService.test.mjs` / `mvcSubsidyService.test.mjs` 已被上游删除；现存 wallet 测试另有 11 处 base 既有失败，均与本 PR 无关 |

**复现路径（验证 R1 修复）**：建群任务 → 派长回合 worker → worker 回 `[WORKING]` 后不重标但持续发言 >20 分钟 → 修复前：被标 `unreachable` + chair 收到重派提示；修复后：保持 `working`，无升级；完全静默 >20 分钟仍触发原升级。

## 五、回源锚点

- 宿主日志 `~/Library/Logs/IDBots/main.log`：E1=L80072 `02:53:35.012 小红 [WORKING] signal stale (20+ min)`；E4=L80063/80064 `02:49:49 delivery-failure notice…(Not enough balance)` + `Send failed (task 37, bot 8): Not enough balance`；E6=L80087 `02:56:38.029 8 deliverable(s), conclusion captured`。
- 宿主数据库 `~/Library/Application Support/IDBots/idbots.sqlite`（时间均为 UTC）：`group_task_status_events` id97 planning→executing @17:59:43、id98 executing→review @18:56:13；`group_task_transitions` id61/62 reason=`[STATUS:EXECUTING] tag`/`[STATUS:REVIEW] tag`；`group_chat_messages` tag 发出 18:56:03(小红一句话口径)/18:56:04(审计文档口径，UTC) → 转换 18:56:13(UTC)，间隔 **9–10 秒**；`group_task_members` 小红 id146 `unreachable`@18:53:35(UTC)、chair id144 `working`。
- 审计全档：`IDBots-state-sync-evidence-audit.md`（S3，小红，72 行）。

## 六、待 owner / 维护者确认

1. 现象 1（status 长期 `executing`）当前 v0.5.4 两层均无复现缺陷、已缓解；**若仍复现，按复现路径另开 issue 追踪**（本 PR 不改 DB 状态机、不改 UI 层）。
2. R3（验收摘要链上核验）、R4（余额告警回写）是否纳入后续 PR——建议跟进，但需独立评估发送/告警的失败语义。

## 附：规格备注

- 行号均基于基线 `012557f6` 工作树**实测**；S1 报告中的常量行号（`:280/:282`）经复核修正为 `:382`（UNREACHABLE=30）/`:384`（TIMEOUT=20），本 PR 描述不采用旧行号。
- 按 chair 终裁，PR 正文刻意不出现"分钟级延迟 / 1min 摄取延迟"（无证据，不采用）；本文亦不含该表述。
- PR 正文可直接采用本文「摘要～四」段落（中文）；如需英文版可由维护者或 owner 一键翻译，内容无损失。

---
*本描述由 5F-Studio（群任务 #38 S2 规格轨）产出，供 fork+push+PR（S5）直接使用。*
