### PR TITLE
chore(lint): remove three stale eslint-disable directives that fail the lint gate

### DIFF
--- a/src/main/libs/llmSafeText.ts
+++ b/src/main/libs/llmSafeText.ts
@@ -21,7 +21,6 @@
  * recombined halves vanishing.
  */
 export function stripLoneSurrogates(text: string): string {
-  // eslint-disable-next-line no-misleading-character-class
   return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '');
 }
 

--- a/src/main/libs/opcatInscribe.ts
+++ b/src/main/libs/opcatInscribe.ts
@@ -6,7 +6,6 @@
  * use @opcat-labs/scrypt-ts-opcat instead of standard bitcoinjs-lib.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyOpcat = any;
 
 const OPCAT_WALLET_API = 'https://wallet-api.opcatlabs.io';

--- a/src/renderer/components/settings/MemorySettings.tsx
+++ b/src/renderer/components/settings/MemorySettings.tsx
@@ -342,7 +342,6 @@ const MemorySettings: React.FC<{ onClose: () => void }> = ({ onClose }) => {
 
   const handleDeleteKnowledge = async (entry: CoworkKnowledgeEntry) => {
     if (metabotId == null) return;
-    // eslint-disable-next-line no-alert
     if (!window.confirm(i18nService.t('memoryKnowledgeDeleteHint'))) return;
     try {
       const ok = await coworkService.deleteKnowledge({ id: entry.id, metabotId });


### PR DESCRIPTION
## Problem

On a clean checkout of v0.6.1 (cffb1a23), `npm run lint` fails with 3 errors — all of them the directives themselves being flagged as unused:

```
src/main/libs/llmSafeText.ts
  24:3  error  Unused eslint-disable directive (no problems were reported from 'no-misleading-character-class')
src/main/libs/opcatInscribe.ts
  9:1  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')
src/renderer/components/settings/MemorySettings.tsx
  345:5  error  Unused eslint-disable directive (no problems were reported from 'no-alert')
```

Because the lint script uses `--report-unused-disable-directives --max-warnings 0`, stale directives hard-fail the gate for every contributor from a fresh clone.

## Fix

Delete the three stale directive lines (3 deletions, 0 insertions). Code semantics untouched:
- llmSafeText.ts — lone-surrogate regex no longer trips no-misleading-character-class
- opcatInscribe.ts — the deliberate any alias no longer trips the rule
- MemorySettings.tsx — window.confirm usage no longer trips no-alert

## Verification

On v0.6.1 with deps installed: `npm run lint` before: 3 errors → after: exit 0. Diff is exactly 3 deleted lines.