### PR TITLE
fix(tests): restore the three test files referenced by test:wallet, test:subsidy, test:im-gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ tests/*
 !tests/groupChatAllowChatSkillsRuntime.test.mjs
 !tests/groupTaskStore.test.mjs
 !tests/groupTasksI18nKeys.test.mjs
+!tests/metabotWalletService.test.mjs
+!tests/mvcSubsidyService.test.mjs
+!tests/imGatewayConnectivity.test.mjs
 !tests/groupTaskService.test.mjs
 !tests/groupChatBackfill.test.mjs
 !tests/groupChatMsgIndexMigration.test.mjs

--- a/tests/imGatewayConnectivity.test.mjs
+++ b/tests/imGatewayConnectivity.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * IM Gateway connectivity tests.
+ * - Telegram probe: trim token, retry, success/fail/network error handling.
+ * Run: npm run compile:electron && node --test tests/imGatewayConnectivity.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { mock } from 'node:test';
+
+const require = createRequire(import.meta.url);
+const axios = require('axios');
+const { probeTelegramAuth } = require('../dist-electron/main/im/telegramProbe.js');
+
+function restoreAxiosGet() {
+  try {
+    mock.reset();
+  } catch (_) {
+    // no-op if not supported
+  }
+}
+
+test('probeTelegramAuth: success returns message with bot username', async () => {
+  mock.method(axios, 'get', async () => ({
+    data: { ok: true, result: { id: 123, username: 'idbots_test_bot', first_name: 'Test' } },
+    status: 200,
+  }));
+  try {
+    const message = await probeTelegramAuth('123456:ABC-DEF', { timeoutMs: 5000, retries: 1 });
+    assert.ok(message.includes('@idbots_test_bot'), 'message should include bot username');
+    assert.ok(
+      message.includes('鉴权通过') || message.includes('authentication succeeded'),
+      'message should indicate success'
+    );
+  } finally {
+    restoreAxiosGet();
+  }
+});
+
+test('probeTelegramAuth: trims token before request', async () => {
+  let capturedUrl = '';
+  mock.method(axios, 'get', async (url) => {
+    capturedUrl = url;
+    return { data: { ok: true, result: { username: 'trimmed_bot' } }, status: 200 };
+  });
+  try {
+    await probeTelegramAuth('  \n  123:token  \n  ', { timeoutMs: 5000, retries: 1 });
+    assert.ok(capturedUrl.includes('123:token'), 'URL should use trimmed token without surrounding spaces');
+    assert.ok(!capturedUrl.includes('\n'), 'URL should not contain newlines');
+  } finally {
+    restoreAxiosGet();
+  }
+});
+
+test('probeTelegramAuth: empty token throws', async () => {
+  await assert.rejects(
+    () => probeTelegramAuth(''),
+    { message: /Bot token is required/ }
+  );
+  await assert.rejects(
+    () => probeTelegramAuth('   \n  '),
+    { message: /Bot token is required/ }
+  );
+});
+
+test('probeTelegramAuth: invalid token (401) throws with API description', async () => {
+  mock.method(axios, 'get', async () => ({
+    data: { ok: false, description: 'Unauthorized' },
+    status: 200,
+  }));
+  try {
+    await assert.rejects(
+      () => probeTelegramAuth('bad-token', { timeoutMs: 5000, retries: 1 }),
+      { message: /Unauthorized/ }
+    );
+  } finally {
+    restoreAxiosGet();
+  }
+});
+
+test('probeTelegramAuth: network timeout throws user-friendly message', async () => {
+  const timeoutErr = new Error('timeout of 5000ms exceeded');
+  timeoutErr.code = 'ECONNABORTED';
+  mock.method(axios, 'get', async () => {
+    throw timeoutErr;
+  });
+  try {
+    await assert.rejects(
+      () => probeTelegramAuth('123:token', { timeoutMs: 5000, retries: 1 }),
+      { message: /连接 Telegram API 超时|Timed out connecting to the Telegram API/ }
+    );
+  } finally {
+    restoreAxiosGet();
+  }
+});
+
+test('probeTelegramAuth: ENOTFOUND throws user-friendly message', async () => {
+  const err = new Error('getaddrinfo ENOTFOUND api.telegram.org');
+  err.code = 'ENOTFOUND';
+  mock.method(axios, 'get', async () => {
+    throw err;
+  });
+  try {
+    await assert.rejects(
+      () => probeTelegramAuth('123:token', { timeoutMs: 5000, retries: 1 }),
+      { message: /无法连接 api\.telegram\.org|Cannot reach api\.telegram\.org/ }
+    );
+  } finally {
+    restoreAxiosGet();
+  }
+});

--- a/tests/metabotWalletService.test.mjs
+++ b/tests/metabotWalletService.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MAIN_ENTRY_PATH = path.join(__dirname, '..', 'dist-electron', 'main.js');
+
+const FIXTURE_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const FIXTURE_PATH = "m/44'/10001'/0'/0/0";
+const FIXTURE_GLOBAL_META_ID = 'idq1970463ym8fqmgawe4lylktne97ahhw4kqehkch';
+
+test('compile:electron preserves the root Electron entry layout', () => {
+  assert.equal(existsSync(MAIN_ENTRY_PATH), true, `expected clean compile output at ${MAIN_ENTRY_PATH}`);
+});
+
+test('createMetaBotWallet preserves the extracted shared identity semantics', async () => {
+  const { createMetaBotWallet } = require('../dist-electron/main/services/metabotWalletService.js');
+  const result = await createMetaBotWallet({
+    mnemonic: FIXTURE_MNEMONIC,
+    path: FIXTURE_PATH,
+  });
+
+  assert.deepEqual(result, {
+    mnemonic: FIXTURE_MNEMONIC,
+    path: FIXTURE_PATH,
+    public_key: '0321e4ffeaea35361f12a676a7f48f24bc2b292fdb20d5980fafcc86bc3780370a',
+    chat_public_key: '04f6b1d713f8e4a00515996cd2e0fd1f00460c08aa17793bd39d53c15ef6b10531c2485f34c37189e85e7723c90598111a845f31871f3b1bf6d080e60f3e929773',
+    mvc_address: '15Lofqw6Kpa6P8WnTYXKvmPyw3UZvvQWrB',
+    btc_address: '15Lofqw6Kpa6P8WnTYXKvmPyw3UZvvQWrB',
+    doge_address: 'D9UuD6sjdEUNv8hPC8WtUXZapBCsFn67jo',
+    metaid: '1dde986762a582142fa908419eed375c76d683c0414ed67bb08cbea8c0fe2b4f',
+    globalmetaid: FIXTURE_GLOBAL_META_ID,
+    chat_public_key_pin_id: '',
+  });
+});
+
+test('normalizeRawGlobalMetaId continues to use the shared normalization path', () => {
+  const { normalizeRawGlobalMetaId } = require('../dist-electron/main/shared/globalMetaId.js');
+  assert.equal(normalizeRawGlobalMetaId(`  ${FIXTURE_GLOBAL_META_ID.toUpperCase()}  `), FIXTURE_GLOBAL_META_ID);
+  assert.equal(normalizeRawGlobalMetaId(`metaid:${FIXTURE_GLOBAL_META_ID}`), null);
+});

--- a/tests/mvcSubsidyService.test.mjs
+++ b/tests/mvcSubsidyService.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { requestMvcGasSubsidy } = require('../dist-electron/main/services/mvcSubsidyService.js');
+
+const FIXTURE_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const FIXTURE_PATH = "m/44'/10001'/0'/0/0";
+const FIXTURE_ADDRESS = '15Lofqw6Kpa6P8WnTYXKvmPyw3UZvvQWrB';
+
+test('requestMvcGasSubsidy completes the init-only flow when mnemonic is omitted', async () => {
+  const calls = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ stage: 'init' })
+    };
+  };
+
+  try {
+    const result = await requestMvcGasSubsidy({
+      mvcAddress: FIXTURE_ADDRESS
+    });
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.step1, { stage: 'init' });
+    assert.equal(calls.length, 1);
+    assert.match(String(calls[0].url), /address-init$/);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('requestMvcGasSubsidy completes the reward flow when mnemonic is present', async () => {
+  const calls = [];
+  const originalFetch = global.fetch;
+  const originalSetTimeout = global.setTimeout;
+
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ stage: calls.length === 1 ? 'init' : 'reward' })
+    };
+  };
+  global.setTimeout = ((callback, _ms, ...args) => {
+    callback(...args);
+    return 0;
+  });
+
+  try {
+    const result = await requestMvcGasSubsidy({
+      mvcAddress: FIXTURE_ADDRESS,
+      mnemonic: FIXTURE_MNEMONIC,
+      path: FIXTURE_PATH
+    });
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.step1, { stage: 'init' });
+    assert.deepEqual(result.step2, { stage: 'reward' });
+    assert.equal(calls.length, 2);
+    assert.match(String(calls[0].url), /address-init$/);
+    assert.match(String(calls[1].url), /address-reward$/);
+    assert.equal(typeof calls[1].options.headers['X-Signature'], 'string');
+    assert.equal(typeof calls[1].options.headers['X-Public-Key'], 'string');
+  } finally {
+    global.fetch = originalFetch;
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test('requestMvcGasSubsidy rejects a missing mvcAddress without any network call', async () => {
+  const originalFetch = global.fetch;
+  let called = false;
+  global.fetch = async () => {
+    called = true;
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+
+  try {
+    const result = await requestMvcGasSubsidy({ mvcAddress: '' });
+    assert.equal(result.success, false);
+    assert.match(result.error, /mvcAddress is required/);
+    assert.equal(called, false, 'should fail fast before any fetch');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Problem

`npm run test:wallet`, `test:subsidy` and `test:im-gateway` all fail on a clean checkout:

```
Could not find 'tests/metabotWalletService.test.mjs'
Could not find 'tests/mvcSubsidyService.test.mjs'
Could not find 'tests/imGatewayConnectivity.test.mjs'
```

Root cause: `.gitignore` uses a `tests/*` whitelist. These three files were untracked as 'local tooling' in March/April (b5d80e04, ee84594c) and later lost, but the package.json scripts kept referencing them. The production modules they cover (`metabotWalletService`, `mvcSubsidyService`, `im/telegramProbe`) are alive and wired into main.ts.

## Fix

Restore the three test files from their last tracked versions in git history, adapted to the current compiled layout (`dist-electron/main/...`), with assertions aligned to the current bilingual (tApp) message texts:

- `tests/metabotWalletService.test.mjs` — BIP44 fixture vectors (abandon×11/about): addresses, metaid, globalmetaid, plus the compile-layout probe
- `tests/mvcSubsidyService.test.mjs` — init-only and full reward flows with mocked fetch/signing, plus a fail-fast guard test
- `tests/imGatewayConnectivity.test.mjs` — telegram probe: success, token trim, empty/invalid token, timeout, ENOTFOUND

Also whitelist the three paths in `.gitignore` (3 lines) so they stay tracked.

## Verification

On v0.6.1 (cffb1a23), clean deps:
- `npm run test:wallet` → 3 pass / 0 fail
- `npm run test:subsidy` → 3 pass / 0 fail
- `npm run test:im-gateway` → 6 pass / 0 fail
- `npm run lint` → exit 0